### PR TITLE
Add David devDependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/TheFourFifths/consus-client.svg?branch=dev)](https://travis-ci.org/TheFourFifths/consus-client)
 [![codecov](https://codecov.io/gh/TheFourFifths/consus/branch/dev/graph/badge.svg)](https://codecov.io/gh/TheFourFifths/consus)
+[![devDependency Status](https://david-dm.org/TheFourFifths/consus-client/dev-status.svg)](https://david-dm.org/TheFourFifths/consus-client?type=dev)
 
 ## Developing
 


### PR DESCRIPTION
### Summary

This is a trivial change which adds a David badge for our npm devDependencies.

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :white_check_mark:

### How to Review

1. View [the david-badge branch](https://github.com/TheFourFifths/consus-client/tree/david-badge#consus-client)
2. Witness the stunning David badge
3. Click the badge, which should bring you to a list of our devDependencies on david-dm.org

### Links

Put links to Jira tickets, and anything else, here.

- https://david-dm.org/
- https://david-dm.org/TheFourFifths/consus-client?type=dev