### PR TITLE
Hotfix/coverage report

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,4 +1,5 @@
 {
+    "all": true,
     "include": [
         "src/**/*.js"
     ],

--- a/.nycrc
+++ b/.nycrc
@@ -1,5 +1,6 @@
 {
     "all": true,
+    "cache": true,
     "include": [
         "src/**/*.js"
     ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - 'node' # ensure we're always running on the latest version of Node.js
   - '6'
   - '4'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,9 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - npm test
+  - npm run coverage
 
 after_success:
-  - npm run coverage
   - bash <(curl -s https://codecov.io/bash)
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,8 @@ cache:
   directories:
     - node_modules
 
-addons:
-  apt:
-    packages:
-      - xvfb
-      - wine
-      - wine-gecko1.4
-
 install:
   - npm install
-
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3 # give xvfb some time to start
 
 script:
   - npm run coverage
@@ -37,18 +25,3 @@ notifications:
       - secure: "NGn87q+6FfLVKwuC0j0IbqT5uJgZUTEiSZwSMzZnVpnI0f27sT4cRQDEJpfKge9GJoMyPUNR8rfYJVX5zSLEV+jXV6sCxnQO3PDNSPJyvBjQuuiNF/ZNItEc+TEg3QCiv2s9PjcVQfc2r7F6+tVG5Ce+vfTpsgRZplfAG3PAYtSePHUTbWhDvARq5eTMW++P1oqaxhL0KxGuQMKBqjU2S+LAt1ky7UdhZqu6+6LY1oaaTDjl8Yvn/GdRklD39aWW6vx2Z2kvuFW2Stq9vtQ0GFZdt8ttTbn2l8nwAuOluIFvseooTtClDfcVDutQD42TD5/pRGjSHSaNmGbMCEcMKxQ55e4gY5KUkWdEMXIq0u9gr5xQa63pq/tQoSni/9YOs4jtFLYYU0ZWr6zY6cpqka7q8uxE22P61abLTIlEbSGatNsTgKoX5Upnj2U/L8BKbcWG4YHwXdlG6F7qyMIxTArYd9aja3nTLgXzwhT2f0WgwwB+vDv5LoQHNm2H2VXrS4rwQ5lhD5DGzFvQFl8WS+p7EHLibHN2s+ZiU8k+LvVN88THDlun+G5jVAoJAkg83OVguU284BZC+6kHbxMtjMm3T9lgAAXp+mcWaL0Jopm+JTlRvnT5hKyJVklKtWB0Gn4ox73qsSAc7OrX2P7ZrZ6ztITWNA6LdPquQVYZBYA="
     on_success: change
     on_failure: always
-
-before_deploy: "npm run package"
-
-deploy:
-  provider: releases
-  api_key:
-    secure: "w/RNsuiRF3qyVQ6myUAaVUh3+vCTmYLkFEWN7A+oqcm6sZ2WSYz/G5zJJHriaFjjvj6vtx14Q9mulcwaCcCckvQsHzYv8JL5ioDytaIWxdKqUBTRZ9761o4niATfYtMFq2T/D4eLJa6ul7DOqZCtK5gLJPMkRCrHKpvJjsh9IbKuucIveTq0mD6Lsc3V2BccWxUr6iXRW8/LKQzXDvJ8qNH2OoSTiSSTSYyyk2MD+GlacSUeWlDcJ6uGJfnqJWs1ejFxbJZHkw4+DaGPSstQ6+9fj39414DROA4XZ2cD+sz0gRv5kDKAxWQZhuGa5ZQPhrhhLeym5C5JtUqt7VYnDqs7BiBe6Uib1RLYqvWDe+AZUmS1v8GRfvkmFmQE0RM/yzbCWm/zqQaemk9df05nCv3E2RnZDAy+PiR4IDGqD0Anq4E9aciyZMroQEDJrmMEhWl59lfGMC9s2AU7y47DKttSuJyYfUx4x1jNv8NlmOYF0FKBXOtWMXoUsoG8yCz2V98We1Yr2tnAeh/ZjYYALxbQf/P4kGjTuMYQEKiWj4ePYsp6R/VTM2VTa2aPle0PoC2sLrBKmVaXxALAsBF0Jvrx01zw2bvQ40CkAIJLvXuTonltTQwlCzoCLWqAF9EHgJRAaAjMZHKc71PCB/48i1RkoqrRSQz5rMBtRH/AOWY="
-  file:
-    - "Consus-Client-linux.zip"
-    - "Consus-Client-macos.zip"
-    - "Consus-Client-win.zip"
-  skip_cleanup: true
-  on:
-    tags: true
-    node: '6'

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,10 @@ coverage:
       default:
         url: secret:zAChUP65Q3h28t2CYkf2vhL+54O0I8A9SMmSPmc3FiecRJdoOv2ekTUMh+mYW3FY6pJnXXGEqjPlhBe2Oj78CyPO6V3yBqToOP8Y0inPgKTMZzfFlX+UYWZoNJEtMD0hrmoUnVpZr/VIpPh0n2dgHrjVPHaChz8VmBWFdlXyBUY=
         attachments: "diff, sunburst"
+  status:
+    project:
+      default:
+        target: auto
 
 fixes:
-  - ".dist/lib/::src/lib/"
+  - ".dist/::src/"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-plugin-istanbul": "^2.0.1",
+    "babel-plugin-istanbul": "^3.0.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-register": "^6.16.3",
@@ -57,7 +57,7 @@
     "grunt-eslint": "^19.0.0",
     "grunt-inline": "^0.3.6",
     "grunt-mocha-cli": "2.1.0",
-    "nyc": "^8.3.0",
+    "nyc": "^9.0.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-router": "^2.8.1",


### PR DESCRIPTION
### Summary

- Enable coverage reporting for _all_ files, even the ones that don't have tests
- Hopefully speed-up Travis CI test speed by:
  - caching instrumented source
  - only running the test suite once by running `npm run coverage` in the `script` stage (coverage is only computed, not checked)
  - stop (attempting) to package the Electron app, since it was timing out anyway

**Ignore the decreased coverage reported by codecov for this PR.**

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: :white_check_mark: 

### How to Review

- Read the diff
- Witness the decrease in code coverage

### Links

- [`babel-plugin-istanbul` changelog](https://github.com/istanbuljs/babel-plugin-istanbul/compare/v2.0.1...v3.0.0)
- [codecov.io commit status docs](http://docs.codecov.io/docs/commit-status)
- [`nyc` changelog](https://github.com/istanbuljs/nyc/compare/v8.3.0...v9.0.1)
