### PR TITLE
TFF-100: Toast Text

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
     "grunt-inline": "^0.3.6",
     "grunt-mocha-cli": "2.1.0",
     "nyc": "^9.0.1",
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2",
+    "react": "^15.4.1",
+    "react-addons-css-transition-group": "^15.4.1",
+    "react-dom": "^15.4.1",
     "react-router": "^2.8.1",
     "request": "^2.75.0"
   }

--- a/src/store/toast-store.js
+++ b/src/store/toast-store.js
@@ -1,35 +1,35 @@
 import { Store } from 'consus-core/flux';
 
-let messages = [];
+let toasts = [];
 let nextId = 0;
 
-class Toast extends Store {
+class ToastStore extends Store {
 
     getToasts() {
-        return messages;
+        return toasts;
     }
 
 }
 
 const store = new ToastStore();
 
-function addMessage(text) {
-    messages.push({
+function addToast(text) {
+    toasts.push({
         id: nextId,
-        text: data.text
+        text
     });
     nextId ++;
 }
 
 store.registerHandler('CREATE_TOAST', data => {
-    addMessage(data.text);
+    addToast(data.text);
     store.emitChange();
 });
 
 store.registerHandler('POP_TOAST', data => {
-    let index = messages.findIndex(message => message.id === data.id);
+    let index = toasts.findIndex(toast => toast.id === data.id);
     if (index > -1) {
-        messages.splice(index, 1);
+        toasts.splice(index, 1);
         store.emitChange();
     }
 });

--- a/src/store/toast-store.js
+++ b/src/store/toast-store.js
@@ -1,5 +1,7 @@
 import { Store } from 'consus-core/flux';
 
+const DEFAULT_TIME_UNTIL_POP = 5000; // 5 seconds
+
 let toasts = [];
 let nextId = 0;
 
@@ -13,10 +15,11 @@ class ToastStore extends Store {
 
 const store = new ToastStore();
 
-function addToast(text) {
+function addToast(text, timeout = DEFAULT_TIME_UNTIL_POP) {
     toasts.push({
         id: nextId,
-        text
+        text,
+        timeout
     });
     nextId ++;
 }
@@ -27,7 +30,7 @@ store.registerHandler('CLEAR_ALL_DATA', () => {
 });
 
 store.registerHandler('CREATE_TOAST', data => {
-    addToast(data.text);
+    addToast(data.text, data.timeout);
     store.emitChange();
 });
 

--- a/src/store/toast-store.js
+++ b/src/store/toast-store.js
@@ -21,6 +21,11 @@ function addToast(text) {
     nextId ++;
 }
 
+store.registerHandler('CLEAR_ALL_DATA', () => {
+    toasts = [];
+    nextId = 0;
+});
+
 store.registerHandler('CREATE_TOAST', data => {
     addToast(data.text);
     store.emitChange();

--- a/src/store/toast-store.js
+++ b/src/store/toast-store.js
@@ -1,0 +1,37 @@
+import { Store } from 'consus-core/flux';
+
+let messages = [];
+let nextId = 0;
+
+class Toast extends Store {
+
+    getToasts() {
+        return messages;
+    }
+
+}
+
+const store = new ToastStore();
+
+function addMessage(text) {
+    messages.push({
+        id: nextId,
+        text: data.text
+    });
+    nextId ++;
+}
+
+store.registerHandler('CREATE_TOAST', data => {
+    addMessage(data.text);
+    store.emitChange();
+});
+
+store.registerHandler('POP_TOAST', data => {
+    let index = messages.findIndex(message => message.id === data.id);
+    if (index > -1) {
+        messages.splice(index, 1);
+        store.emitChange();
+    }
+});
+
+export default store;

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -18,3 +18,4 @@ textarea
 @import 'create-model-form.styl'
 @import 'create-item-form.styl'
 @import 'index.styl'
+@import 'toasts.styl'

--- a/src/styles/toasts.styl
+++ b/src/styles/toasts.styl
@@ -1,0 +1,19 @@
+#toasts
+    position: fixed
+    bottom: 0
+    left: 0
+    width: 100%
+    padding-bottom: 1em
+
+    .toast
+        background-color: #464646
+        color: #fbfbfb
+        border-radius: 0.5em
+        padding: 1em
+        width: 20em
+        margin: 0 auto 1em auto
+        text-align: center
+        cursor: pointer
+
+        &:hover
+            background-color: #727272

--- a/src/styles/toasts.styl
+++ b/src/styles/toasts.styl
@@ -7,13 +7,27 @@
 
     .toast
         background-color: #464646
+        width: 20em
         color: #fbfbfb
         border-radius: 0.5em
         padding: 1em
-        width: 20em
         margin: 0 auto 1em auto
         text-align: center
         cursor: pointer
 
         &:hover
-            background-color: #727272
+            background-color: #262626
+
+        &.toast-enter
+            opacity: 0
+
+            &.toast-enter-active
+                opacity: 1
+                transition: opacity 700ms ease-in
+
+        &.toast-leave
+            opacity: 1
+
+            &.toast-leave-active
+                opacity: 0
+                transition: opacity 300ms ease-in

--- a/src/views/app.jsx
+++ b/src/views/app.jsx
@@ -2,20 +2,22 @@ import React from 'react';
 import { Dispatcher } from 'consus-core/flux';
 import AuthenticationStore from '../store/authentication-store';
 import ErrorStore from '../store/error-store';
+import ToastStore from '../store/toast-store';
 
 import ListenerComponent from '../lib/listener-component.jsx';
 import Omnibar from './components/omnibar.jsx';
 import Models from './pages/models.jsx';
 import ErrorModal from './components/error-modal.jsx';
+import Toast from './components/toast.jsx';
 
 export default class App extends ListenerComponent {
 
-    constructor() {
-        super();
-    }
-
     getStores() {
-        return [AuthenticationStore, ErrorStore];
+        return [
+            AuthenticationStore,
+            ErrorStore,
+            ToastStore
+        ];
     }
 
     getState() {
@@ -23,12 +25,19 @@ export default class App extends ListenerComponent {
             hasError: ErrorStore.hasError(),
             loggedIn: AuthenticationStore.loggedIn(),
             errorTag: ErrorStore.getTag(),
-            errorMessage: ErrorStore.getError()
+            errorMessage: ErrorStore.getError(),
+            toasts: ToastStore.getToasts().slice(0, 3)
         };
     }
 
     closeError() {
         Dispatcher.handleAction('CLEAR_ERROR', {});
+    }
+
+    popToast(id) {
+        Dispatcher.handleAction('POP_TOAST', {
+            id
+        });
     }
 
     render() {
@@ -43,6 +52,9 @@ export default class App extends ListenerComponent {
         return (
             <div id='app'>
                 <ErrorModal active={ErrorStore.hasError()} onClose={this.closeError} message={this.state.errorMessage} />
+                <div id='toasts'>
+                    {this.state.toasts.map(t => <Toast key={t.id} onPop={this.popToast.bind(this, t.id)}>{t.text}</Toast>)}
+                </div>
                 <Omnibar />
                 <div id='children'>
                   {this.props.children}

--- a/src/views/app.jsx
+++ b/src/views/app.jsx
@@ -8,7 +8,7 @@ import ListenerComponent from '../lib/listener-component.jsx';
 import Omnibar from './components/omnibar.jsx';
 import Models from './pages/models.jsx';
 import ErrorModal from './components/error-modal.jsx';
-import Toast from './components/toast.jsx';
+import Toasts from './components/toasts.jsx';
 
 export default class App extends ListenerComponent {
 
@@ -34,12 +34,6 @@ export default class App extends ListenerComponent {
         Dispatcher.handleAction('CLEAR_ERROR', {});
     }
 
-    popToast(id) {
-        Dispatcher.handleAction('POP_TOAST', {
-            id
-        });
-    }
-
     render() {
         if (!this.state.loggedIn) {
             return (
@@ -52,9 +46,7 @@ export default class App extends ListenerComponent {
         return (
             <div id='app'>
                 <ErrorModal active={ErrorStore.hasError()} onClose={this.closeError} message={this.state.errorMessage} />
-                <div id='toasts'>
-                    {this.state.toasts.map(t => <Toast key={t.id} onPop={this.popToast.bind(this, t.id)}>{t.text}</Toast>)}
-                </div>
+                <Toasts toasts={this.state.toasts} />
                 <Omnibar />
                 <div id='children'>
                   {this.props.children}

--- a/src/views/components/toast.jsx
+++ b/src/views/components/toast.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-const TIME_UNTIL_POP = 5000; // 5 seconds
-
 export default class Toast extends React.Component {
 
     constructor(props) {
@@ -12,7 +10,7 @@ export default class Toast extends React.Component {
     componentDidMount() {
         setTimeout(() => {
             this.pop();
-        }, TIME_UNTIL_POP);
+        }, this.props.timeout);
     }
 
     pop() {

--- a/src/views/components/toast.jsx
+++ b/src/views/components/toast.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class Toast extends React.Component {
+
+    render() {
+        return (
+            <div className='toast'>
+                {this.props.children}
+            </div>
+        );
+    }
+
+}

--- a/src/views/components/toast.jsx
+++ b/src/views/components/toast.jsx
@@ -1,10 +1,30 @@
 import React from 'react';
 
+const TIME_UNTIL_POP = 5000; // 5 seconds
+
 export default class Toast extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.popped = false;
+    }
+
+    componentDidMount() {
+        setTimeout(() => {
+            this.pop();
+        }, TIME_UNTIL_POP);
+    }
+
+    pop() {
+        if (!this.popped) {
+            this.popped = true;
+            this.props.onPop();
+        }
+    }
 
     render() {
         return (
-            <div className='toast'>
+            <div className='toast' onClick={this.pop.bind(this)}>
                 {this.props.children}
             </div>
         );

--- a/src/views/components/toasts.jsx
+++ b/src/views/components/toasts.jsx
@@ -18,7 +18,7 @@ export default class Toasts extends React.Component {
                 <ReactCSSTransitionGroup transitionName='toast' transitionEnterTimeout={700} transitionLeaveTimeout={300}>
                     {this.props.toasts.map(toast => {
                         return (
-                            <Toast key={toast.id} onPop={this.popToast.bind(this, toast.id)}>
+                            <Toast key={toast.id} onPop={this.popToast.bind(this, toast.id)} timeout={toast.timeout}>
                                 {toast.text}
                             </Toast>
                         );

--- a/src/views/components/toasts.jsx
+++ b/src/views/components/toasts.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import { Dispatcher } from 'consus-core/flux';
+
+import Toast from './toast.jsx';
+
+export default class Toasts extends React.Component {
+
+    popToast(id) {
+        Dispatcher.handleAction('POP_TOAST', {
+            id
+        });
+    }
+
+    render() {
+        return (
+            <div id='toasts'>
+                <ReactCSSTransitionGroup transitionName='toast' transitionEnterTimeout={700} transitionLeaveTimeout={300}>
+                    {this.props.toasts.map(toast => {
+                        return (
+                            <Toast key={toast.id} onPop={this.popToast.bind(this, toast.id)}>
+                                {toast.text}
+                            </Toast>
+                        );
+                    })}
+                </ReactCSSTransitionGroup>
+            </div>
+        );
+    }
+
+}

--- a/test/unit/store/toast-store.js
+++ b/test/unit/store/toast-store.js
@@ -1,0 +1,70 @@
+import { Dispatcher } from 'consus-core/flux';
+import ToastStore from '../../../.dist/store/toast-store';
+import { assert } from 'chai';
+
+describe('ToastStore', () => {
+
+    beforeEach(() => {
+        Dispatcher.handleAction('CLEAR_ALL_DATA');
+        Dispatcher.handleAction('CREATE_TOAST', {
+            text: 'A'
+        });
+        Dispatcher.handleAction('CREATE_TOAST', {
+            text: 'B'
+        });
+        Dispatcher.handleAction('CREATE_TOAST', {
+            text: 'C'
+        });
+    });
+
+    it('should add a toast message', () => {
+        assert.lengthOf(ToastStore.getToasts(), 3);
+        Dispatcher.handleAction('CREATE_TOAST', {
+            text: 'D'
+        });
+        assert.lengthOf(ToastStore.getToasts(), 4);
+        assert.strictEqual(ToastStore.getToasts()[3].id, 3);
+        assert.strictEqual(ToastStore.getToasts()[3].text, 'D');
+    });
+
+    it('should pop the first toast message', () => {
+        Dispatcher.handleAction('POP_TOAST', {
+            id: 0
+        });
+        assert.lengthOf(ToastStore.getToasts(), 2);
+        assert.strictEqual(ToastStore.getToasts()[0].text, 'B');
+        assert.strictEqual(ToastStore.getToasts()[1].text, 'C');
+    });
+
+    it('should pop the second toast message', () => {
+        Dispatcher.handleAction('POP_TOAST', {
+            id: 1
+        });
+        assert.lengthOf(ToastStore.getToasts(), 2);
+        assert.strictEqual(ToastStore.getToasts()[0].text, 'A');
+        assert.strictEqual(ToastStore.getToasts()[1].text, 'C');
+    });
+
+    it('should pop the last toast message', () => {
+        Dispatcher.handleAction('POP_TOAST', {
+            id: 2
+        });
+        assert.lengthOf(ToastStore.getToasts(), 2);
+        assert.strictEqual(ToastStore.getToasts()[0].text, 'A');
+        assert.strictEqual(ToastStore.getToasts()[1].text, 'B');
+    });
+
+    it('should pop all toast messages', () => {
+        Dispatcher.handleAction('POP_TOAST', {
+            id: 0
+        });
+        Dispatcher.handleAction('POP_TOAST', {
+            id: 1
+        });
+        Dispatcher.handleAction('POP_TOAST', {
+            id: 2
+        });
+        assert.lengthOf(ToastStore.getToasts(), 0);
+    });
+
+});

--- a/test/unit/store/toast-store.js
+++ b/test/unit/store/toast-store.js
@@ -27,6 +27,23 @@ describe('ToastStore', () => {
         assert.strictEqual(ToastStore.getToasts()[3].text, 'D');
     });
 
+    it('should have a default timeout of 5 seconds', () => {
+        assert.lengthOf(ToastStore.getToasts(), 3);
+        Dispatcher.handleAction('CREATE_TOAST', {
+            text: 'D'
+        });
+        assert.strictEqual(ToastStore.getToasts()[3].timeout, 5000);
+    });
+
+    it('should be able to define the timeout', () => {
+        assert.lengthOf(ToastStore.getToasts(), 3);
+        Dispatcher.handleAction('CREATE_TOAST', {
+            text: 'D',
+            timeout: 1234
+        });
+        assert.strictEqual(ToastStore.getToasts()[3].timeout, 1234);
+    });
+
     it('should pop the first toast message', () => {
         Dispatcher.handleAction('POP_TOAST', {
             id: 0


### PR DESCRIPTION
### Summary

This PR adds toasts to the client. Toasts fade in and out near the bottom of the window, and a limit of 3 toasts are displayed at a time. Each toast expires after being displayed for 5 seconds. Toasts can be clicked to pop them immediately.

![Toast Gif](http://g.recordit.co/3bUE701fD4.gif)


### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :deciduous_tree:

### How to Review

1. Review the code diff.
2. Fetch and `git checkout toast-text-TFF-100` in `consus-client`.
3. Add the following to `src/views/components/toasts.jsx` to simulate new toast messages:

```javascript
    constructor() {
        super();
        let i = 0;
        setInterval(() => {
            i ++;
            Dispatcher.handleAction('CREATE_TOAST', {
                text: 'Message number ' + i + '!'
            });
        }, 1500);
    }
```

4. `npm install`, `npm run build`, and `npm start` to build and launch the client.
5. Play around with the toast messages near the bottom of the window. Make sure they work properly.

### Links

- [TFF-100](https://msoese.atlassian.net/browse/TFF-100)