### PR TITLE
Changed api call to help the server update model counts

### DIFF
--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -202,9 +202,10 @@ export function getModelsForNewItem() {
         hashHistory.push('/items/new');
     });
 }
-export function deleteItem(address){
+export function deleteItem(item){
     return del('item', {
-        itemAddress: address
+        itemAddress: item.address,
+        modelAddress: item.modelAddress
     }).then(data => {
         Dispatcher.handleAction('ITEMS_RECEIVED', data);
     }).catch(data => {

--- a/src/views/components/item.jsx
+++ b/src/views/components/item.jsx
@@ -50,7 +50,7 @@ export default class Item extends React.Component {
                 <div className="actionArea">
                     <img src="../assets/images/add.svg"/>
                     <img src="../assets/images/edit.svg"/>
-                    <img onClick={deleteItem.bind(this, this.state.item.address)} src="../assets/images/delete.svg"/>
+                    <img onClick={deleteItem.bind(this, this.state.item)} src="../assets/images/delete.svg"/>
                 </div>
                 <div className="clear"></div>
             </div>


### PR DESCRIPTION
### Summary

When creating and deleting items, the number of models that the item belongs to is now incremented or decremented appropriately.

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: 🎄 

### How to Review

1. Run both this branch and the branch of the same name on Consus.
2. Click the view all items button.
3. Click the add an item button
4. Add an item. (keep in mind that just clicking the button without changing the dropdown will create a broken item, so be sure to change the selected item.)
5. Go to the main screen and click on the view all models button.
6. Verify that the number of models of the type of item you created has increased by 1 (check the defaults in the server's model store or just view this before adding an item)
7. Now go to the view all items screen and delete an item.
8. Return to the view all models screen and the model count of the item you deleted, it should have decreased by 1

### Links

SISTER PR https://github.com/TheFourFifths/consus/pull/35
