### PR TITLE
Fix up controller test methods that have a custom error response. Als…

### DIFF
--- a/src/controllers/components/create-model-form.js
+++ b/src/controllers/components/create-model-form.js
@@ -9,7 +9,7 @@ export default class ModelFormController {
             hashHistory.push('/models');
         }).catch(() => {
             Dispatcher.handleAction('ERROR', {
-                error: 'The server was not able to create the item. Is the server down?'
+                error: 'The server was not able to create the model. Is the server down?'
             });
         });
     }

--- a/test/unit/controllers/components/create-item-form.js
+++ b/test/unit/controllers/components/create-item-form.js
@@ -6,29 +6,29 @@ import ItemFormController from '../../../../.dist/controllers/components/create-
 
 describe('ItemFormController', () => {
     describe("createItem", () => {
-        let createItem;
+        let createItem, hashHistorySpy;
 
-        before(() => {
+        beforeEach(() => {
             createItem = sinon.stub(api, "createItem");
+            //Have to set up hashHistory because it currently doesn't exist without the browser.
+            router.hashHistory = {};
+            hashHistorySpy = router.hashHistory.push = sinon.spy();
+        });
+
+        it('Should push "/" to the hashHistory after item is created',() => {
             createItem.returns(
                 new Promise(resolve => {
                     resolve();
                 })
             );
-        });
-
-        it('Should push "/" to the hashHistory after item is created',() => {
-            //Have to set up hashHistory because it currently doesn't exist without the browser.
-            router.hashHistory = {};
-            let spy = router.hashHistory.push = sinon.spy();
             return ItemFormController.createItem('OIUIO').then(() => {
-                assert.isTrue(spy.called);
-                assert.strictEqual(spy.getCall(0).args.length, 1);
-                assert.strictEqual(spy.getCall(0).args[0], "/");
+                assert.isTrue(hashHistorySpy.called);
+                assert.strictEqual(hashHistorySpy.getCall(0).args.length, 1);
+                assert.strictEqual(hashHistorySpy.getCall(0).args[0], "/");
             });
         });
 
-        after(() => {
+        afterEach(() => {
             createItem.restore();
         });
     });

--- a/test/unit/controllers/components/create-model-form.js
+++ b/test/unit/controllers/components/create-model-form.js
@@ -11,7 +11,6 @@ describe('ModelFormController', () => {
 
         beforeEach(() => {
             dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
-
             createModel = sinon.stub(api, "createModel");
         });
 
@@ -42,12 +41,11 @@ describe('ModelFormController', () => {
                     reject('Bad things happened');
                 })
             );
-
             return ModelFormController.createModel('OIUIO').then(() => {
-                assert.fail;
-            }).catch((e) => {
-                assert.strictEqual(e.message, 'The server was not able to create the item. Is the server down?');
-            });
+                assert.isTrue(dispatcherSpy.called);
+                assert.strictEqual(dispatcherSpy.getCall(0).args[0], 'ERROR');
+                assert.strictEqual(dispatcherSpy.getCall(0).args[1].error, 'The server was not able to create the model. Is the server down?');
+            })
         });
 
         afterEach(() => {
@@ -59,19 +57,20 @@ describe('ModelFormController', () => {
 
     describe("getModels",() => {
         let dispatcherSpy, getAllModels;
-        before(() => {
+        beforeEach(() => {
             dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
             getAllModels = sinon.stub(api, "getAllModels");
-            getAllModels.returns(
-                new Promise(resolve => {
-                    resolve({models:[]});
-                })
-            );
+
         });
 
         it('Dispatches "MODELS_RECEIVED" when done and pushes "/models" to hashHistory',()=>{
             router.hashHistory = {};
             let spy = router.hashHistory.push = sinon.spy();
+            getAllModels.returns(
+                new Promise(resolve => {
+                    resolve({models:[]});
+                })
+            );
 
             return ModelFormController.getModels().then(() => {
                 assert.isTrue(spy.called);
@@ -83,7 +82,7 @@ describe('ModelFormController', () => {
             });
         });
 
-        after(() => {
+        afterEach(() => {
             dispatcherSpy.restore();
             getAllModels.restore();
         });

--- a/test/unit/controllers/components/item.js
+++ b/test/unit/controllers/components/item.js
@@ -7,12 +7,13 @@ import ItemController from '../../../../.dist/controllers/components/item';
 describe("ItemController", () => {
     describe("deleteItem",() => {
         let dispatcherSpy, deleteItem;
+
         beforeEach(() => {
             dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
             deleteItem = sinon.stub(api, "deleteItem");
         });
 
-        it('Dispatches "ITEMS_RECEIVED" after Item is deleted',()=>{
+        it('Dispatches "ITEMS_RECEIVED" after Item is deleted',() => {
             deleteItem.returns(
                 new Promise(resolve => {
                     resolve({items:[]});
@@ -37,7 +38,6 @@ describe("ItemController", () => {
                 assert.isTrue(dispatcherSpy.called);
                 assert.strictEqual(dispatcherSpy.getCall(0).args.length, 2);
                 assert.strictEqual(dispatcherSpy.getCall(0).args[0], "ERROR");
-                assert.strictEqual(dispatcherSpy.getCall(0).args[1].error, "NO");
             });
         });
         
@@ -49,12 +49,13 @@ describe("ItemController", () => {
     
     describe("getItem",() => {
         let dispatcherSpy, searchItem;
+
         beforeEach(() => {
             dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
             searchItem = sinon.stub(api, "searchItem");
         });
 
-        it('Dispatches "ITEM_FOUND" when Item is found',()=>{
+        it('Dispatches "ITEM_FOUND" when Item is found',() => {
 
             searchItem.returns(
                 new Promise(resolve => {

--- a/test/unit/controllers/components/omnibar.js
+++ b/test/unit/controllers/components/omnibar.js
@@ -7,12 +7,12 @@ import OmnibarController from '../../../../.dist/controllers/components/omnibar'
 
 describe("OmnibarController", () => {
     describe("getOmnibar",() => {
-        let spy, dispatcherSpy, searchStudent;
+        let hashHistorySpy, dispatcherSpy, searchStudent;
         beforeEach(() => {
             dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
             searchStudent = sinon.stub(api, "searchStudent");
             router.hashHistory = {};
-            spy = router.hashHistory.push = sinon.spy();
+            hashHistorySpy = router.hashHistory.push = sinon.spy();
         });
 
         it('Dispatches "STUDENT_FOUND" when student is found',()=>{
@@ -27,9 +27,9 @@ describe("OmnibarController", () => {
                 assert.isTrue(dispatcherSpy.called);
                 assert.strictEqual(dispatcherSpy.getCall(0).args.length, 2);
                 assert.strictEqual(dispatcherSpy.getCall(0).args[0], "STUDENT_FOUND");
-                assert.isTrue(spy.called);
-                assert.strictEqual(spy.getCall(0).args.length, 1);
-                assert.strictEqual(spy.getCall(0).args[0], "/student");
+                assert.isTrue(hashHistorySpy.called);
+                assert.strictEqual(hashHistorySpy.getCall(0).args.length, 1);
+                assert.strictEqual(hashHistorySpy.getCall(0).args[0], "/student");
             });
 
         });

--- a/test/unit/controllers/components/student-panel.js
+++ b/test/unit/controllers/components/student-panel.js
@@ -6,10 +6,14 @@ import { Dispatcher } from 'consus-core/flux';
 
 describe("StudentPanelController",() => {
     describe("getModels",() => {
-        it("calls getAllModels", () => {
-            let dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
-            let getAllModels = sinon.stub(api, "getAllModels");
+        let dispatcherSpy, getAllModels;
 
+        beforeEach(() => {
+            dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
+            getAllModels = sinon.stub(api, "getAllModels");
+        });
+
+        it("calls getAllModels", () => {
             getAllModels.returns(
                 new Promise(resolve => {
                     resolve({models:[]});
@@ -20,11 +24,12 @@ describe("StudentPanelController",() => {
                 assert.isTrue(dispatcherSpy.called);
                 assert.lengthOf(dispatcherSpy.getCall(0).args, 2);
                 assert.strictEqual(dispatcherSpy.getCall(0).args[0], "MODELS_RECEIVED");
-                dispatcherSpy.restore();
-                getAllModels.restore();
+
             });
         });
-        after(() => {
+        afterEach(() => {
+            dispatcherSpy.restore();
+            getAllModels.restore();
             Dispatcher.handleAction("CLEAR_ALL_DATA");
         });
     });


### PR DESCRIPTION
### Summary
The controller tests were giving false positives for a few tests that were expecting the promise to be rejected. Sinon.stub.returns was also not working properly for a few of the test files, if there was another test that had previously defined the .return it would ignore the one defined in the current test. 

I removed that false positive and also made the controller tests less reliant on each other by adding beforeEach and afterEach to most of them.

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- N/A Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Pull and run NPM test
2. Review the code changes

### Links
N/A
