### PR TITLE
Create a toast for item creation

### DIFF
--- a/src/controllers/components/create-item-form.js
+++ b/src/controllers/components/create-item-form.js
@@ -4,8 +4,9 @@ import { Dispatcher } from 'consus-core/flux';
 
 export default class ItemFormController {
     static createItem(modelAddress) {
-        return createItem(modelAddress).then(()=>{
+        return createItem(modelAddress).then(response => {
             hashHistory.push('/');
+            Dispatcher.handleAction('ITEM_CREATED', response);
         });
     }
 

--- a/test/unit/controllers/components/create-item-form.js
+++ b/test/unit/controllers/components/create-item-form.js
@@ -18,7 +18,10 @@ describe('ItemFormController', () => {
         it('Should push "/" to the hashHistory after item is created',() => {
             createItem.returns(
                 new Promise(resolve => {
-                    resolve();
+                    resolve({
+                        address: 'iGwEZUvfA',
+                        modelName: 'resistor'
+                    });
                 })
             );
             return ItemFormController.createItem('OIUIO').then(() => {


### PR DESCRIPTION
### Summary

The toast store was prepared for the ITEM_CREATED action, but the controller never created this action. This PR creates that action, triggering the appropriate toast show here:

![image](https://cloud.githubusercontent.com/assets/5055041/22053734/5a31c21a-dd18-11e6-860e-b40136343d3b.png)


### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Run the server on the `dev` branch
2. Run the client on the `hotfix-item-create-toast-TFF-160` branch
3. Click to view all items
4. Click to create an item
5. Create an item
6. Observe the toast, checking for item address and model name

### Links

- [TFF-160](https://msoese.atlassian.net/browse/TFF-160)
