### PR TITLE
Single item styling fixed, cartitems have different className

### DIFF
--- a/src/styles/items.styl
+++ b/src/styles/items.styl
@@ -80,3 +80,84 @@
                 padding: 5px
                 &:hover
                     background: lightgray
+.item
+    background: lightblue
+    display: block
+    height: auto
+    padding: 5px
+    margin-bottom: 5px
+    border-radius: 20px
+    word-wrap: break-word
+
+    .picArea
+        display: inline-block
+        vertical-align: top
+        padding: 7px
+
+        img
+            height: 75px
+            width:inherit
+
+    .titleArea
+        display: inline-block
+        vertical-align: top
+        width: 10%
+
+        h2
+            text-align: center
+            margin: 0
+
+        .modelLink
+            display: block
+            text-align: center
+
+    .infoArea
+        display: inline-block
+        vertical-align: top
+        width: 70%
+
+        .descriptionArea
+            display: inline-block
+            vertical-align: top
+            padding-right: 10px
+            width: 40%
+
+            h3
+                text-align: left
+                margin: 0
+
+            p
+                margin: 0
+                padding-top: 5px
+        .faultArea
+            display: inline-block
+            width: 30%
+            vertical-align: top
+
+            h3
+                text-align: left
+                margin: 0
+
+            p
+                margin: 0
+                padding-top: 5px
+
+        .miscArea
+            padding: 10px
+            display: inline-block
+            width: 20%
+            vertical-align: top
+
+    .actionArea
+        display: inline-block
+        vertical-align: top
+        float: right
+        padding-right: 10px
+
+        img
+            width: 50px
+            height: 33px
+            display: block
+            padding: 5px
+            &:hover
+                background: lightgray

--- a/src/views/components/cart-panel.jsx
+++ b/src/views/components/cart-panel.jsx
@@ -45,9 +45,9 @@ export default class CartPanel extends React.Component {
             return <div><br/><i>Cart is empty.</i><br/><br/></div>;
         }
         return (
-            <ul className='items'>
+            <ul className='cartItems'>
                 {this.props.itemAddresses.map((itemAddress, i) => {
-                    return <li className='item' key={i}>{itemAddress}</li>;
+                    return <li className='cartItem' key={i}>{itemAddress}</li>;
                 })}
             </ul>
         );

--- a/test/functional/admin-override-item-checkout.js
+++ b/test/functional/admin-override-item-checkout.js
@@ -122,9 +122,9 @@ describe('Admin override on item checkout', function () {
             }
         });
         return app.client.keys('iGwEZVHHE').then(() => {
-            return app.client.waitForVisible('ul.items li.item');
+            return app.client.waitForVisible('ul.cartItems li.cartItem');
         }).then(() => {
-            return app.client.getText('ul.items li.item');
+            return app.client.getText('ul.cartItems li.cartItem');
         }).then(item => {
             assert.include(item, 'iGwEZVHHE');
             mockServer.validate();


### PR DESCRIPTION
### Summary

Fix styling for a single items' page. The functional tests needed the div's to be more targeted which involved changing the style sheets to have an additional parent. That caused an individual items' page to become non-styled. This is the fix for that and adjusting the tests accordingly

### Checklist

- [not needed ] Have you added unit and functional tests as appropriate?
- [ not needed] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Lookup student 123456
2. Checkout an item
3. Complete checkout
4. Click the item in the cart panel
5. Verify the styling is there(it's ugly i know, i don't wanna hear it)
