### PR TITLE
[TFF-170] Update client functional tests to work as integration tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,8 @@ module.exports = function(grunt) {
                         '.test/functional/item-checkout.js',
                         '.test/functional/item-checkin.js',
                         '.test/functional/admin-override-item-checkout.js',
-                        '.test/functional/delete-model.js'
+                        '.test/functional/delete-model.js',
+                        '.test/functional/delete-item.js'
                     ]
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,8 @@ module.exports = function(grunt) {
                 },
                 files: {
                     src: [
-                        '.test/functional/create-item.js'
+                        '.test/functional/create-item.js',
+                        '.test/functional/item-checkout.js'
                     ]
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,6 +97,7 @@ module.exports = function(grunt) {
                 files: {
                     src: [
                         '.test/functional/student-lookup.js',
+                        '.test/functiona/view-models.js',
                         '.test/functional/create-item.js',
                         '.test/functional/item-checkout.js'
                     ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,6 +87,16 @@ module.exports = function(grunt) {
                 files: {
                     src: ['.test/functional/**/*.js']
                 }
+            },
+            integration: {
+                options: {
+                    env: {
+                        test: 'integration'
+                    }
+                },
+                files: {
+                    src: ['.test/functional/**/*.js']
+                }
             }
         },
         clean: {
@@ -183,7 +193,8 @@ module.exports = function(grunt) {
 
     grunt.registerTask('build', ['clean:dist', 'babel:dist', 'browserify:dist', 'stylus', 'copy', 'inline']);
     grunt.registerTask('lint', ['eslint']);
-    grunt.registerTask('test', ['lint', 'build', 'clean:test', 'babel:test', 'mochacli']);
-    grunt.registerTask('lintless-test', ['build', 'clean:test', 'babel:test', 'mochacli']);
+    grunt.registerTask('test', ['lint', 'build', 'clean:test', 'babel:test', 'mochacli:unit', 'mochacli:functional']);
+    grunt.registerTask('lintless-test', ['build', 'clean:test', 'babel:test', 'mochacli:unit', 'mochacli:functional']);
+    grunt.registerTask('integration-test', ['build', 'clean:test', 'babel:test', 'mochacli:integration']);
     grunt.registerTask('package', ['build', 'electron', 'compress']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,6 +96,7 @@ module.exports = function(grunt) {
                 },
                 files: {
                     src: [
+                        '.test/functional/student-lookup.js',
                         '.test/functional/create-item.js',
                         '.test/functional/item-checkout.js'
                     ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,7 +101,8 @@ module.exports = function(grunt) {
                         '.test/functional/create-item.js',
                         '.test/functional/item-checkout.js',
                         '.test/functional/item-checkin.js',
-                        '.test/functional/admin-override-item-checkout.js'
+                        '.test/functional/admin-override-item-checkout.js',
+                        '.test/functional/delete-model.js'
                     ]
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,7 +99,8 @@ module.exports = function(grunt) {
                         '.test/functional/student-lookup.js',
                         '.test/functiona/view-models.js',
                         '.test/functional/create-item.js',
-                        '.test/functional/item-checkout.js'
+                        '.test/functional/item-checkout.js',
+                        '.test/functional/item-checkin.js'
                     ]
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,7 +95,9 @@ module.exports = function(grunt) {
                     }
                 },
                 files: {
-                    src: ['.test/functional/**/*.js']
+                    src: [
+                        '.test/functional/create-item.js'
+                    ]
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,8 @@ module.exports = function(grunt) {
                         '.test/functiona/view-models.js',
                         '.test/functional/create-item.js',
                         '.test/functional/item-checkout.js',
-                        '.test/functional/item-checkin.js'
+                        '.test/functional/item-checkin.js',
+                        '.test/functional/admin-override-item-checkout.js'
                     ]
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,16 @@ module.exports = function(grunt) {
             },
             functional: {
                 files: {
-                    src: ['.test/functional/**/*.js']
+                    src: [
+                        '.test/functional/student-lookup.js',
+                        '.test/functiona/view-models.js',
+                        '.test/functional/create-item.js',
+                        '.test/functional/item-checkout.js',
+                        '.test/functional/item-checkin.js',
+                        '.test/functional/admin-override-item-checkout.js',
+                        '.test/functional/delete-model.js',
+                        '.test/functional/delete-item.js'
+                    ]
                 }
             },
             integration: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,9 +78,14 @@ module.exports = function(grunt) {
             options: {
                 reporter: 'spec'
             },
-            all: {
+            unit: {
                 files: {
-                    src: ['.test/**/*.js']
+                    src: ['.test/unit/**/*.js']
+                }
+            },
+            functional: {
+                files: {
+                    src: ['.test/functional/**/*.js']
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm start
 
 * `npm test`: Run the test suite
 * `npm run lint`: Run the linter
+* `npm run integration-test`: Run the integration tests (requires server listening on port 8081)
+* `npm run lintless-test`: Run the test suite without linting
 * `npm run build`: Build the usable .dist directory
 * `npm run coverage`: Generate a code coverage report
 
@@ -40,5 +42,7 @@ npm start
         * `components`: Smaller components
         * `pages`: Entire pages
 * `test`: The project's tests
-    * `unit`: Unit tests
     * `functional`: Functional tests
+    * `test-cases`: Test case values
+    * `unit`: Unit tests
+    * `util`: Testing utilities

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babelify": "^7.3.0",
     "body-parser": "^1.15.2",
     "chai": "3.5.0",
-    "consus-core": "^0.5.6",
+    "consus-core": "^0.6.0",
     "cross-env": "^3.1.1",
     "diff-json": "^0.1.11",
     "electron-prebuilt": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "coverage": "cross-env NODE_ENV=test BABEL_ENV=test nyc npm test && nyc report --reporter=text-lcov > coverage.lcov",
     "test": "grunt test",
     "lintless-test": "grunt lintless-test",
+    "integration-test": "grunt integration-test",
     "lint": "grunt lint",
     "package": "grunt package"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "chai": "3.5.0",
     "consus-core": "^0.6.0",
     "cross-env": "^3.1.1",
-    "diff-json": "^0.1.11",
     "electron-prebuilt": "1.4.2",
     "eslint-plugin-react": "^6.3.0",
     "express": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "chai": "3.5.0",
     "consus-core": "^0.5.6",
     "cross-env": "^3.1.1",
+    "diff-json": "^0.1.11",
     "electron-prebuilt": "1.4.2",
     "eslint-plugin-react": "^6.3.0",
     "express": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "grunt-eslint": "^19.0.0",
     "grunt-inline": "^0.3.6",
     "grunt-mocha-cli": "2.1.0",
+    "moment-timezone": "^0.5.11",
     "nyc": "^9.0.1",
     "react": "^15.4.1",
     "react-addons-css-transition-group": "^15.4.1",

--- a/src/controllers/components/omnibar.js
+++ b/src/controllers/components/omnibar.js
@@ -4,6 +4,9 @@ import { hashHistory } from 'react-router';
 
 export default class OmnibarController {
     static getStudent(id) {
+        if (typeof id === 'string') {
+            id = parseInt(id);
+        }
         return searchStudent(id).then(student =>{
             Dispatcher.handleAction("STUDENT_FOUND", student);
             hashHistory.push('/student');

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -16,7 +16,7 @@ export function changePort(port) {
     PORT = port;
 }
 
-function call(endpoint, method, qs, json) {
+export function call(endpoint, method, qs, json) {
     let options = {
         uri: `${PROTOCOL}://${HOST}:${PORT}/api/${endpoint}`,
         method

--- a/src/lib/clock.js
+++ b/src/lib/clock.js
@@ -1,0 +1,15 @@
+import moment from 'moment-timezone';
+
+export function getNextDueTimestamp() {
+    let timestamp = moment.tz(Date.now(), 'America/Chicago');
+    let hour = parseInt(timestamp.format('H'));
+    let minute = parseInt(timestamp.format('m'));
+    // check for times past 4:50pm
+    if (hour > 16 || (hour === 16 && minute >= 50)) {
+        // increment to the next day
+        timestamp = timestamp.add(1, 'd');
+    }
+    timestamp.hour(17).minute(0).second(0);
+    let dueTime = parseInt(timestamp.format('X'));
+    return dueTime;
+}

--- a/test/functional/admin-override-item-checkout.js
+++ b/test/functional/admin-override-item-checkout.js
@@ -34,7 +34,7 @@ describe('Admin override on item checkout', function () {
     it('navigates to the student page', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
                 id: '123456'
             },
@@ -58,7 +58,7 @@ describe('Admin override on item checkout', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -106,7 +106,7 @@ describe('Admin override on item checkout', function () {
     it('adds an item to the cart', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 address: 'iGwEZVHHE'
             },
@@ -134,7 +134,7 @@ describe('Admin override on item checkout', function () {
     it('prompts for a pin to check out', () => {
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkout',
+            endpoint: 'checkout',
             json: {
                 adminCode: null,
                 studentId: '123456',
@@ -157,7 +157,7 @@ describe('Admin override on item checkout', function () {
     it('completes the checkout with the admin pin', () => {
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkout',
+            endpoint: 'checkout',
             json: {
                 adminCode: '3214',
                 studentId: '123456',
@@ -169,7 +169,7 @@ describe('Admin override on item checkout', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
                 id: '123456'
             },

--- a/test/functional/admin-override-item-checkout.js
+++ b/test/functional/admin-override-item-checkout.js
@@ -2,6 +2,9 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import items from '../test-cases/items';
+import models from '../test-cases/models';
+import students from '../test-cases/students';
 
 describe('Admin override on item checkout', function () {
 
@@ -36,24 +39,11 @@ describe('Admin override on item checkout', function () {
             method: 'get',
             endpoint: 'student',
             qs: {
-                id: '123456'
+                id: '111111'
             },
             response: {
                 status: 'success',
-                data: {
-                    id: 123456,
-                    name: 'John von Neumann',
-                    status: 'C - Current',
-                    items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            modelAddress: 'm8y7nEtAe',
-                            timestamp: Math.floor(Date.now() / 1000) - 1000000000
-                        }
-                    ],
-                    email: 'vonneumann@msoe.edu',
-                    major: 'Chemical Engineering & Mathematics'
-                }
+                data: students[1]
             }
         });
         mockServer.expect({
@@ -62,43 +52,27 @@ describe('Admin override on item checkout', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            name: 'Resistor',
-                            description: 'V = IR',
-                            manufacturer: 'Manufacturer',
-                            vendor: 'Mouzer',
-                            location: 'Shelf 14',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 10.5,
-                            count: 20,
-                            items: [
-                                'iGwEZUvfA'
-                            ]
-                        }
-                    ]
+                    models
                 }
             }
         });
-        return app.client.keys('123456').then(() => {
+        return app.client.keys('111111').then(() => {
             return app.client.waitForVisible('#student', 1000000);
         }).then(() => {
             return app.client.getText('#student .student .name');
         }).then(name => {
-            assert.strictEqual(name, 'John von Neumann');
+            assert.strictEqual(name, students[1].name);
             return app.client.getText('#student .student .id');
         }).then(id => {
-            assert.strictEqual(id, '123456');
+            assert.strictEqual(id, '111111');
             return app.client.elements('#student .student .equipment .item-info');
         }).then(items => {
             assert.lengthOf(items.value, 1);
             return app.client.getText('#student .student .equipment .item-info');
         }).then(item => {
-            assert.include(item, 'Resistor');
+            assert.include(item, 'Transistor');
             assert.include(item, 'overdue');
-            assert.include(item, 'iGwEZUvfA');
+            assert.include(item, 'iGwEZVeaT');
             mockServer.validate();
         });
     });
@@ -108,30 +82,24 @@ describe('Admin override on item checkout', function () {
             method: 'get',
             endpoint: 'item',
             qs: {
-                address: 'iGwEZVHHE'
+                address: 'iGwEZUvfA'
             },
             response: {
                status: 'success',
-               data: {
-                  address: 'iGwEZVHHE',
-                  modelAddress: 'm8y7nEtAe',
-                  status: 'AVAILABLE',
-                  isFaulty: false,
-                  faultDescription: ''
-               }
+               data: items[0]
             }
         });
-        return app.client.keys('iGwEZVHHE').then(() => {
+        return app.client.keys('iGwEZUvfA').then(() => {
             return app.client.waitForVisible('ul.cartItems li.cartItem');
         }).then(() => {
             return app.client.getText('ul.cartItems li.cartItem');
         }).then(item => {
-            assert.include(item, 'iGwEZVHHE');
+            assert.include(item, 'iGwEZUvfA');
             mockServer.validate();
         });
     });
 
-    it('prompts for a pin to check out', () => {
+    it.skip('prompts for a pin to check out', () => {
         mockServer.expect({
             method: 'post',
             endpoint: 'checkout',
@@ -154,7 +122,7 @@ describe('Admin override on item checkout', function () {
         });
     });
 
-    it('completes the checkout with the admin pin', () => {
+    it.skip('completes the checkout with the admin pin', () => {
         mockServer.expect({
             method: 'post',
             endpoint: 'checkout',

--- a/test/functional/admin-override-item-checkout.js
+++ b/test/functional/admin-override-item-checkout.js
@@ -82,30 +82,30 @@ describe('Admin override on item checkout', function () {
             method: 'get',
             endpoint: 'item',
             qs: {
-                address: 'iGwEZUvfA'
+                address: 'iGwEZVHHE'
             },
             response: {
                status: 'success',
-               data: items[0]
+               data: items[1]
             }
         });
-        return app.client.keys('iGwEZUvfA').then(() => {
+        return app.client.keys('iGwEZVHHE').then(() => {
             return app.client.waitForVisible('ul.cartItems li.cartItem');
         }).then(() => {
             return app.client.getText('ul.cartItems li.cartItem');
         }).then(item => {
-            assert.include(item, 'iGwEZUvfA');
+            assert.include(item, 'iGwEZVHHE');
             mockServer.validate();
         });
     });
 
-    it.skip('prompts for a pin to check out', () => {
+    it('prompts for a pin to check out', () => {
         mockServer.expect({
             method: 'post',
             endpoint: 'checkout',
             json: {
                 adminCode: null,
-                studentId: 123456,
+                studentId: 111111,
                 itemAddresses: ['iGwEZVHHE']
             },
             response: {
@@ -122,46 +122,30 @@ describe('Admin override on item checkout', function () {
         });
     });
 
-    it.skip('completes the checkout with the admin pin', () => {
+    it('completes the checkout with the admin pin', () => {
         mockServer.expect({
             method: 'post',
             endpoint: 'checkout',
             json: {
                 adminCode: '3214',
-                studentId: 123456,
+                studentId: 111111,
                 itemAddresses: ['iGwEZVHHE']
             },
             response: {
                 status: 'success'
             }
         });
+        items[1].status = 'CHECKED_OUT';
+        students[1].items.push(items[1]);
         mockServer.expect({
             method: 'get',
             endpoint: 'student',
             qs: {
-                id: '123456'
+                id: '111111'
             },
             response: {
                 status: 'success',
-                data: {
-                    id: 123456,
-                    name: 'John von Neumann',
-                    status: 'C - Current',
-                    items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            modelAddress: 'm8y7nEtAe',
-                            timestamp: Math.floor(Date.now() / 1000) - 1000000000
-                        },
-                        {
-                            address: 'iGwEZVHHE',
-                            modelAddress: 'm8y7nEtAe',
-                            timestamp: Math.floor(Date.now() / 1000) + 1000000000
-                        }
-                    ],
-                    email: 'vonneumann@msoe.edu',
-                    major: 'Chemical Engineering & Mathematics'
-                }
+                data: students[1]
             }
         });
         return app.client.click('.modal .modal-content input').then(() => {

--- a/test/functional/create-item.js
+++ b/test/functional/create-item.js
@@ -42,7 +42,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: models.slice(0, 2)
+                    models
                 }
             }
         });
@@ -109,7 +109,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: models.slice(0, 2)
+                    models
                 }
             }
         });
@@ -179,7 +179,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: models.slice(0, 2)
+                    models
                 }
             }
         });

--- a/test/functional/create-item.js
+++ b/test/functional/create-item.js
@@ -7,7 +7,7 @@ import models from '../test-cases/models';
 
 describe('Creating an Item', function () {
 
-    this.timeout(20000);
+    this.timeout(10000);
     let app;
     let mockServer = new MockServer();
 
@@ -50,7 +50,7 @@ describe('Creating an Item', function () {
             method: 'post',
             endpoint: 'item',
             json: {
-                modelAddress: 'm8y7nEtAe'
+                modelAddress: models[0].address
             },
             response: {
                 status: 'success',
@@ -60,6 +60,7 @@ describe('Creating an Item', function () {
                 }
             }
         });
+        models[0].count ++;
         return app.client.click('#view-items').then(() => {
             return app.client.waitForVisible('#items', 5000);
         }).then(() => {
@@ -69,9 +70,9 @@ describe('Creating an Item', function () {
         }).then(() => {
             return app.client.getValue('.create-item-form select option');
         }).then(vals => {
-            assert.include(vals, 'm8y7nEtAe');
-            assert.include(vals, 'm8y7nFLsT');
-            return app.client.selectByValue('.create-item-form select', 'm8y7nEtAe');
+            assert.include(vals, models[0].address);
+            assert.include(vals, models[1].address);
+            return app.client.selectByValue('.create-item-form select', models[0].address);
         }).then(() => {
             return app.client.submitForm('.create-item-form form');
         }).then(() => {
@@ -80,7 +81,6 @@ describe('Creating an Item', function () {
             return app.client.getText('.toast');
         }).then(text => {
             assert.strictEqual(text, 'New item added: Resistor (iGwEZVvgu)');
-            models[0].count ++;
             return app.client.click('.toast');
         }).then(() => {
             return app.client.waitForVisible('.toast', 10000, true);
@@ -117,7 +117,7 @@ describe('Creating an Item', function () {
             method: 'post',
             endpoint: 'item',
             json: {
-                modelAddress: 'm8y7nFLsT'
+                modelAddress: models[1].address
             },
             response: {
                 status: 'success',
@@ -127,6 +127,7 @@ describe('Creating an Item', function () {
                 }
             }
         });
+        models[1].count ++;
         return app.client.click('#omnibar img').then(() => {
             return app.client.click('#view-items');
         }).then(() => {
@@ -149,9 +150,9 @@ describe('Creating an Item', function () {
         }).then(() => {
             return app.client.getValue('.create-item-form select option');
         }).then(vals => {
-            assert.include(vals, 'm8y7nEtAe');
-            assert.include(vals, 'm8y7nFLsT');
-            return app.client.selectByValue('.create-item-form select', 'm8y7nFLsT');
+            assert.include(vals, models[0].address);
+            assert.include(vals, models[1].address);
+            return app.client.selectByValue('.create-item-form select', models[1].address);
         }).then(() => {
             return app.client.submitForm('.create-item-form form');
         }).then(() => {
@@ -160,7 +161,6 @@ describe('Creating an Item', function () {
             return app.client.getText('.toast');
         }).then(text => {
             assert.strictEqual(text, 'New item added: Transistor (iGwEZW6nn)');
-            models[1].count ++;
             return app.client.click('.toast');
         }).then(() => {
             return app.client.waitForVisible('.toast', 10000, true);

--- a/test/functional/create-item.js
+++ b/test/functional/create-item.js
@@ -5,7 +5,7 @@ import MockServer from '../util/mock-server';
 
 describe('Creating an Item', function () {
 
-    this.timeout(10000);
+    this.timeout(20000);
     let app;
     let mockServer = new MockServer();
 

--- a/test/functional/create-item.js
+++ b/test/functional/create-item.js
@@ -2,6 +2,8 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import items from '../test-cases/items';
+import models from '../test-cases/models';
 
 describe('Creating an Item', function () {
 
@@ -30,29 +32,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            modelAddress: 'm8y7nEtAe',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        },
-                        {
-                            address: 'iGwEZVHHE',
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        },
-                        {
-                            address: 'iGwEZVeaT',
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        }
-                    ]
+                    items: items.slice(0, 3)
                 }
             }
         });
@@ -62,38 +42,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            name: 'Resistor',
-                            description: 'V = IR',
-                            manufacturer: 'Pancakes R\' Us',
-                            vendor: 'Mouzer',
-                            location: 'Shelf 14',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 10.5,
-                            count: 20,
-                            items: [
-                                'iGwEZUvfA',
-                                'iGwEZVHHE',
-                                'iGwEZVeaT'
-                            ]
-                        },
-                        {
-                            address: 'm8y7nFLsT',
-                            name: 'Transistor',
-                            description: 'Something used in computers',
-                            manufacturer: 'Vroom Industries',
-                            vendor: 'Fankserrogatoman Inc',
-                            location: 'Shelf 2',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 4,
-                            count: 10,
-                            items: []
-                        }
-                    ]
+                    models: models.slice(0, 2)
                 }
             }
         });
@@ -131,6 +80,7 @@ describe('Creating an Item', function () {
             return app.client.getText('.toast');
         }).then(text => {
             assert.strictEqual(text, 'New item added: Resistor (iGwEZVvgu)');
+            models[0].count ++;
             return app.client.click('.toast');
         }).then(() => {
             return app.client.waitForVisible('.toast', 10000, true);
@@ -149,36 +99,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            modelAddress: 'm8y7nEtAe',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        },
-                        {
-                            address: 'iGwEZVHHE',
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        },
-                        {
-                            address: 'iGwEZVeaT',
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        },
-                        {
-                            address: 'iGwEZVvgu',
-                            modelAddress: 'm8y7nEtAe',
-                            status: 'AVAILABLE',
-                            isFaulty: false,
-                            faultDescription: ''
-                        }
-                    ]
+                    items: items.slice(0, 4)
                 }
             }
         });
@@ -188,38 +109,7 @@ describe('Creating an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            name: 'Resistor',
-                            description: 'V = IR',
-                            manufacturer: 'Pancakes R\' Us',
-                            vendor: 'Mouzer',
-                            location: 'Shelf 14',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 10.5,
-                            count: 21,
-                            items: [
-                                'iGwEZUvfA',
-                                'iGwEZVHHE',
-                                'iGwEZVeaT'
-                            ]
-                        },
-                        {
-                            address: 'm8y7nFLsT',
-                            name: 'Transistor',
-                            description: 'Something used in computers',
-                            manufacturer: 'Vroom Industries',
-                            vendor: 'Fankserrogatoman Inc',
-                            location: 'Shelf 2',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 4,
-                            count: 10,
-                            items: []
-                        }
-                    ]
+                    models: models.slice(0, 2)
                 }
             }
         });
@@ -270,6 +160,7 @@ describe('Creating an Item', function () {
             return app.client.getText('.toast');
         }).then(text => {
             assert.strictEqual(text, 'New item added: Transistor (iGwEZW6nn)');
+            models[1].count ++;
             return app.client.click('.toast');
         }).then(() => {
             return app.client.waitForVisible('.toast', 10000, true);

--- a/test/functional/create-item.js
+++ b/test/functional/create-item.js
@@ -26,7 +26,7 @@ describe('Creating an Item', function () {
     it('creates a new item', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item/all',
+            endpoint: 'item/all',
             response: {
                 status: 'success',
                 data: {
@@ -56,7 +56,7 @@ describe('Creating an Item', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -92,7 +92,7 @@ describe('Creating an Item', function () {
         });
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/item',
+            endpoint: 'item',
             json: {
                 modelAddress: 'm8y7nEtAe'
             },
@@ -138,7 +138,7 @@ describe('Creating an Item', function () {
     it('tells the user to select a model', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item/all',
+            endpoint: 'item/all',
             response: {
                 status: 'success',
                 data: {
@@ -168,7 +168,7 @@ describe('Creating an Item', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -204,7 +204,7 @@ describe('Creating an Item', function () {
         });
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/item',
+            endpoint: 'item',
             json: {
                 modelAddress: 'm8y7nFLsT'
             },

--- a/test/functional/create-item.js
+++ b/test/functional/create-item.js
@@ -33,22 +33,24 @@ describe('Creating an Item', function () {
                     items: [
                         {
                             address: 'iGwEZUvfA',
-                            faultDesctiption: '',
-                            isFaulty: false,
                             modelAddress: 'm8y7nEtAe',
-                            status: 'AVAILABLE'
-                        }, {
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
+                        },
+                        {
                             address: 'iGwEZVHHE',
-                            faultDescription: '',
-                            isFaulty: false,
                             modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
-                        }, {
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
+                        },
+                        {
                             address: 'iGwEZVeaT',
-                            faultDescription: '',
-                            isFaulty: false,
                             modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
                         }
                     ]
                 }
@@ -63,28 +65,33 @@ describe('Creating an Item', function () {
                     models: [
                         {
                             address: 'm8y7nEtAe',
-                            count: 20,
-                            description: 'V = IR',
-                            faultDescription: '',
-                            isFaulty: false,
-                            items: [ 'iGwEXUvfA', 'iGwEZVHHE', 'iGwEZVeaT' ],
-                            location: 'Shelf 14',
-                            manufacturer: "Pancakes R' Us",
                             name: 'Resistor',
-                            price: 10.5,
-                            vendor: 'Mouzer'
-                        }, {
-                            address: 'm8y7nFLsT',
-                            count: 10,
-                            description: 'Something used in computers',
-                            faultDescription: '',
+                            description: 'V = IR',
+                            manufacturer: 'Pancakes R\' Us',
+                            vendor: 'Mouzer',
+                            location: 'Shelf 14',
                             isFaulty: false,
-                            items: [],
-                            location: 'Shelf 2',
-                            manufacturer: 'Vroom Industries',
+                            faultDescription: '',
+                            price: 10.5,
+                            count: 20,
+                            items: [
+                                'iGwEZUvfA',
+                                'iGwEZVHHE',
+                                'iGwEZVeaT'
+                            ]
+                        },
+                        {
+                            address: 'm8y7nFLsT',
                             name: 'Transistor',
+                            description: 'Something used in computers',
+                            manufacturer: 'Vroom Industries',
+                            vendor: 'Fankserrogatoman Inc',
+                            location: 'Shelf 2',
+                            isFaulty: false,
+                            faultDescription: '',
                             price: 4,
-                            vendor: 'Fankserrogatoman Inc'
+                            count: 10,
+                            items: []
                         }
                     ]
                 }
@@ -145,22 +152,31 @@ describe('Creating an Item', function () {
                     items: [
                         {
                             address: 'iGwEZUvfA',
-                            faultDesctiption: '',
-                            isFaulty: false,
                             modelAddress: 'm8y7nEtAe',
-                            status: 'AVAILABLE'
-                        }, {
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
+                        },
+                        {
                             address: 'iGwEZVHHE',
-                            faultDescription: '',
-                            isFaulty: false,
                             modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
-                        }, {
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
+                        },
+                        {
                             address: 'iGwEZVeaT',
-                            faultDescription: '',
-                            isFaulty: false,
                             modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
+                        },
+                        {
+                            address: 'iGwEZVvgu',
+                            modelAddress: 'm8y7nEtAe',
+                            status: 'AVAILABLE',
+                            isFaulty: false,
+                            faultDescription: ''
                         }
                     ]
                 }
@@ -175,28 +191,33 @@ describe('Creating an Item', function () {
                     models: [
                         {
                             address: 'm8y7nEtAe',
-                            count: 20,
-                            description: 'V = IR',
-                            faultDescription: '',
-                            isFaulty: false,
-                            items: [ 'iGwEXUvfA', 'iGwEZVHHE', 'iGwEZVeaT' ],
-                            location: 'Shelf 14',
-                            manufacturer: "Pancakes R' Us",
                             name: 'Resistor',
-                            price: 10.5,
-                            vendor: 'Mouzer'
-                        }, {
-                            address: 'm8y7nFLsT',
-                            count: 10,
-                            description: 'Something used in computers',
-                            faultDescription: '',
+                            description: 'V = IR',
+                            manufacturer: 'Pancakes R\' Us',
+                            vendor: 'Mouzer',
+                            location: 'Shelf 14',
                             isFaulty: false,
-                            items: [],
-                            location: 'Shelf 2',
-                            manufacturer: 'Vroom Industries',
+                            faultDescription: '',
+                            price: 10.5,
+                            count: 21,
+                            items: [
+                                'iGwEZUvfA',
+                                'iGwEZVHHE',
+                                'iGwEZVeaT'
+                            ]
+                        },
+                        {
+                            address: 'm8y7nFLsT',
                             name: 'Transistor',
+                            description: 'Something used in computers',
+                            manufacturer: 'Vroom Industries',
+                            vendor: 'Fankserrogatoman Inc',
+                            location: 'Shelf 2',
+                            isFaulty: false,
+                            faultDescription: '',
                             price: 4,
-                            vendor: 'Fankserrogatoman Inc'
+                            count: 10,
+                            items: []
                         }
                     ]
                 }
@@ -255,7 +276,7 @@ describe('Creating an Item', function () {
         }).then(() => {
             return app.client.elements('#items .item');
         }).then(elements => {
-            assert.lengthOf(elements.value, 3);
+            assert.lengthOf(elements.value, 4);
             mockServer.validate();
         });
     });

--- a/test/functional/delete-item.js
+++ b/test/functional/delete-item.js
@@ -30,27 +30,7 @@ describe('Deleting an Item', function () {
             response: {
                 status: 'success',
                 data: {
-                    items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            faultDescription: '',
-                            isFaulty: false,
-                            modelAddress: 'm8y7nEtAe',
-                            status: 'AVAILABLE'
-                        }, {
-                            address: 'iGwEZVHHE',
-                            faultDescription: '',
-                            isFaulty: false,
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
-                        }, {
-                            address: 'iGwEZVeaT',
-                            faultDescription: '',
-                            isFaulty: false,
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
-                        }
-                    ]
+                    items
                 }
             }
         });

--- a/test/functional/delete-item.js
+++ b/test/functional/delete-item.js
@@ -26,7 +26,7 @@ describe('Deleting an Item', function () {
     it('deletes an item', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item/all',
+            endpoint: 'item/all',
             response: {
                 status: 'success',
                 data: {
@@ -56,7 +56,7 @@ describe('Deleting an Item', function () {
         });
         mockServer.expect({
             method: 'delete',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 itemAddress: 'iGwEZUvfA',
                 modelAddress: 'm8y7nEtAe'

--- a/test/functional/delete-item.js
+++ b/test/functional/delete-item.js
@@ -2,6 +2,7 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import items from '../test-cases/items';
 
 describe('Deleting an Item', function () {
 
@@ -34,6 +35,7 @@ describe('Deleting an Item', function () {
                 }
             }
         });
+        items.splice(0, 1);
         mockServer.expect({
             method: 'delete',
             endpoint: 'item',
@@ -45,21 +47,7 @@ describe('Deleting an Item', function () {
                 status: 'success',
                 data: {
                     modelName: 'Resistor',
-                    items: [
-                        {
-                            address: 'iGwEZVHHE',
-                            faultDescription: '',
-                            isFaulty: false,
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
-                        }, {
-                            address: 'iGwEZVeaT',
-                            faultDescription: '',
-                            isFaulty: false,
-                            modelAddress: 'm8y7nFLsT',
-                            status: 'AVAILABLE'
-                        }
-                    ]
+                    items
                 }
             }
         });
@@ -68,7 +56,7 @@ describe('Deleting an Item', function () {
         }).then(() => {
             return app.client.elements('#items .item');
         }).then(elements => {
-            assert.lengthOf(elements.value, 3);
+            assert.lengthOf(elements.value, 2);
             return app.client.click('.item:nth-of-type(1) .actionArea img[src*="delete"]');
         }).then(() => {
             return app.client.waitForVisible('.toast', 5000);
@@ -82,7 +70,7 @@ describe('Deleting an Item', function () {
         }).then(() => {
             return app.client.elements('#items .item');
         }).then(elements => {
-            assert.lengthOf(elements.value, 2);
+            assert.lengthOf(elements.value, 1);
             mockServer.validate();
         });
     });

--- a/test/functional/delete-model.js
+++ b/test/functional/delete-model.js
@@ -26,7 +26,7 @@ describe('Deleting a model', function () {
     it('navigates to the models page', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -78,7 +78,7 @@ describe('Deleting a model', function () {
     it('deletes a model', () => {
         mockServer.expect({
             method: 'delete',
-            endpoint: '/api/model',
+            endpoint: 'model',
             qs: {
                 modelAddress: 'm8y7nEtAe'
             },
@@ -105,7 +105,7 @@ describe('Deleting a model', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {

--- a/test/functional/delete-model.js
+++ b/test/functional/delete-model.js
@@ -2,6 +2,7 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import models from '../test-cases/models';
 
 describe('Deleting a model', function () {
 
@@ -30,38 +31,7 @@ describe('Deleting a model', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            name: 'Resistor',
-                            description: 'V = IR',
-                            manufacturer: 'Manufacturer',
-                            vendor: 'Mouzer',
-                            location: 'Shelf 14',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 10.5,
-                            count: 20,
-                            items: [
-                                'iGwEZUvfA'
-                            ]
-                        },
-                        {
-                            address: 'm8y7nFLsT',
-                            name: 'Transistor',
-                            description: 'Something used in computers',
-                            manufacturer: 'Vroom Industries',
-                            vendor: 'Fankserrogatoman Inc',
-                            location: 'Shelf 2',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 4.00,
-                            count: 10,
-                            items: [
-                                'iGwEZVHHE'
-                            ]
-                        }
-                    ]
+                    models
                 }
             }
         });
@@ -80,61 +50,32 @@ describe('Deleting a model', function () {
             method: 'delete',
             endpoint: 'model',
             qs: {
-                modelAddress: 'm8y7nEtAe'
+                modelAddress: models[1].address
             },
             response: {
                 status: 'success',
                 data: {
-                    deletedModel: {
-                        address: 'm8y7nEtAe',
-                        name: 'Resistor',
-                        description: 'V = IR',
-                        manufacturer: 'Pancakes R\' Us',
-                        vendor: 'Mouzer',
-                        location: 'Shelf 14',
-                        isFaulty: false,
-                        faultDescription: '',
-                        price: 10.5,
-                        count: 20,
-                        items: [
-                            'iGwEZUvfA'
-                        ]
-                    }
+                    deletedModel: models[1]
                 }
             }
         });
+        models.splice(1);
         mockServer.expect({
             method: 'get',
             endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        {
-                            address: 'm8y7nFLsT',
-                            name: 'Transistor',
-                            description: 'Something used in computers',
-                            manufacturer: 'Vroom Industries',
-                            vendor: 'Fankserrogatoman Inc',
-                            location: 'Shelf 2',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 4.00,
-                            count: 10,
-                            items: [
-                                'iGwEZVHHE'
-                            ]
-                        }
-                    ]
+                    models
                 }
             }
         });
-        return app.client.click('#models .model:first-child img[src="../assets/images/delete.svg"]').then(() => {
+        return app.client.click('#models div:nth-of-type(2) .model img[src="../assets/images/delete.svg"]').then(() => {
             return app.client.waitForVisible('.modal');
         }).then(() => {
             return app.client.getText('.modal p');
         }).then(text => {
-            assert.include(text, 'Resistor');
+            assert.include(text, 'Transistor');
             return app.client.click('.modal button[type="button"]');
         }).then(() => {
             return app.client.waitForVisible('.modal', 2500, true);
@@ -143,7 +84,7 @@ describe('Deleting a model', function () {
         }).then(() => {
             return app.client.getText('.toast');
         }).then(toast => {
-            assert.strictEqual(toast, 'Resistor (m8y7nEtAe) was deleted');
+            assert.strictEqual(toast, 'Transistor (m8y7nFLsT) was deleted');
         }).then(() => {
             return app.client.elements('#models .model');
         }).then(elements => {

--- a/test/functional/delete-model.js
+++ b/test/functional/delete-model.js
@@ -2,6 +2,7 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import items from '../test-cases/items';
 import models from '../test-cases/models';
 
 describe('Deleting a model', function () {
@@ -85,6 +86,10 @@ describe('Deleting a model', function () {
             return app.client.getText('.toast');
         }).then(toast => {
             assert.strictEqual(toast, 'Transistor (m8y7nFLsT) was deleted');
+            items.splice(5, 1);
+            items.splice(4, 1);
+            items.splice(2, 1);
+            items.splice(1, 1);
         }).then(() => {
             return app.client.elements('#models .model');
         }).then(elements => {

--- a/test/functional/item-checkin.js
+++ b/test/functional/item-checkin.js
@@ -2,6 +2,7 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import items from '../test-cases/items';
 import models from '../test-cases/models';
 import students from '../test-cases/students';
 
@@ -95,6 +96,7 @@ describe('Checking an item in', function () {
             return app.client.getText('.toast');
         }).then(toast => {
             assert.strictEqual(toast, 'Item checked in successfully: Resistor (iGwEZUvfA)');
+            items[0].status = 'AVAILABLE';
             students[0].items.shift();
             return app.client.click('.toast');
         }).then(() => {
@@ -145,6 +147,7 @@ describe('Checking an item in', function () {
             return app.client.getText('.toast');
         }).then(toast => {
             assert.strictEqual(toast, 'Item checked in successfully: Transistor (iGwEZVHHE)');
+            items[1].status = 'AVAILABLE';
             students[0].items.shift();
             return app.client.click('.toast');
         }).then(() => {
@@ -163,6 +166,7 @@ describe('Checking an item in', function () {
             return app.client.getText('.toast');
         }).then(toast => {
             assert.strictEqual(toast, 'Item checked in successfully: Resistor (iGwEZVvgu)');
+            items[3].status = 'AVAILABLE';
             students[0].items.shift();
             return app.client.click('.toast');
         }).then(() => {

--- a/test/functional/item-checkin.js
+++ b/test/functional/item-checkin.js
@@ -34,7 +34,7 @@ describe('Checking an item in', function () {
     it('navigates to the student page', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
                 id: '123456'
             },
@@ -58,7 +58,7 @@ describe('Checking an item in', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -105,7 +105,7 @@ describe('Checking an item in', function () {
     it('checks in the item', () => {
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkin',
+            endpoint: 'checkin',
             json: {
                 studentId: '123456',
                 itemAddress: 'iGwEZUvfA'

--- a/test/functional/item-checkin.js
+++ b/test/functional/item-checkin.js
@@ -52,10 +52,7 @@ describe('Checking an item in', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        models[0],
-                        models[1]
-                    ]
+                    models
                 }
             }
         });

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -53,7 +53,7 @@ describe('Checking an item out', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: models.slice(0, 2)
+                    models
                 }
             }
         });

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -261,7 +261,6 @@ describe('Checking an item out', function () {
           assert.lengthOf(items.value, 3);
           mockServer.validate();
       });
-
     });
 
     it("doesn't allow invalid characters in the item field", () => {
@@ -282,47 +281,35 @@ describe('Checking an item out', function () {
         });
     });
 
-    it.skip("doesn't allow the same items to be added to the cart twice", () => {
+    it("doesn't allow the same items to be added to the cart twice", () => {
         mockServer.expect({
             method: 'get',
             endpoint: 'item',
             qs: {
-                address: 'iGwEZUvfA'
+                address: 'iGwEZW6nn'
             },
             response:{
                 status: 'success',
-                data: {
-                    address: 'iGwEZUvfA',
-                    modelAddress: 'm8y7nEtAe',
-                    status: 'AVAILABLE',
-                    isFaulty: false,
-                    faultDescription: ''
-                }
+                data: items[4]
             }
         });
         mockServer.expect({
             method: 'get',
             endpoint: 'item',
             qs: {
-                address: 'iGwEZUvfA'
+                address: 'iGwEZW6nn'
             },
             response:{
                 status: 'success',
-                data: {
-                    address: 'iGwEZUvfA',
-                    modelAddress: 'm8y7nEtAe',
-                    status: 'AVAILABLE',
-                    isFaulty: false,
-                    faultDescription: ''
-                }
+                data: items[4]
             }
         });
         return app.client.waitForVisible('.cart input[type="text"]').then(() => {
             return app.client.click('.cart input[type="text"]');
         }).then(() => {
-            return app.client.keys('iGwEZUvfA');
+            return app.client.keys('iGwEZW6nn');
         }).then(() => {
-            return app.client.keys('iGwEZUvfA');
+            return app.client.keys('iGwEZW6nn');
         }).then(() => {
             return app.client.waitForVisible('#app .modal', 1000000);
         }).then(() => {

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -5,7 +5,7 @@ import MockServer from '../util/mock-server';
 
 describe('Checking an item out', function () {
 
-    this.timeout(10000);
+    this.timeout(30000);
     let app;
     let mockServer = new MockServer();
 
@@ -41,12 +41,12 @@ describe('Checking an item out', function () {
             response: {
                 status: 'success',
                 data: {
-                    id: '123456',
+                    id: 123456,
                     name: 'John von Neumann',
                     status: 'C - Current',
-                    items: [],
-                    email: 'vonneumann@msoe.edu',
-                    major: 'Chemical Engineering & Mathematics'
+                    email: 'neumannJ@msoe.edu',
+                    major: 'Software Engineering',
+                    items: []
                 }
             }
         });
@@ -114,7 +114,7 @@ describe('Checking an item out', function () {
             endpoint: 'checkout',
             json: {
                 adminCode: null,
-                studentId: '123456',
+                studentId: 123456,
                 itemAddresses: ['iGwEZUvfA']
             },
             response: {
@@ -131,7 +131,7 @@ describe('Checking an item out', function () {
             response: {
                 status: 'success',
                 data: {
-                    id: '123456',
+                    id: 123456,
                     name: 'John von Neumann',
                     status: 'C - Current',
                     items: [
@@ -141,8 +141,8 @@ describe('Checking an item out', function () {
                             timestamp: Math.floor(Date.now() / 1000) + 1000000000
                         }
                     ],
-                    email: 'vonneumann@msoe.edu',
-                    major: 'Chemical Engineering & Mathematics'
+                    email: 'neumannJ@msoe.edu',
+                    major: 'Software Engineering'
                 }
             }
         });
@@ -248,7 +248,7 @@ describe('Checking an item out', function () {
           endpoint: 'checkout',
           json: {
               adminCode: null,
-              studentId: '123456',
+              studentId: 123456,
               itemAddresses: ['iGwEZVeaT','iGwEZVHHE']
           },
           response: {

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -9,7 +9,7 @@ import students from '../test-cases/students';
 
 describe('Checking an item out', function () {
 
-    this.timeout(30000);
+    this.timeout(10000);
     let app;
     let mockServer = new MockServer();
 
@@ -94,6 +94,8 @@ describe('Checking an item out', function () {
                 status: 'success'
             }
         });
+        items[0].status = 'CHECKED_OUT';
+        items[0].timestamp = getNextDueTimestamp();
         mockServer.expect({
             method: 'get',
             endpoint: 'student',
@@ -107,14 +109,7 @@ describe('Checking an item out', function () {
                     name: 'John von Neumann',
                     status: 'C - Current',
                     items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            modelAddress: 'm8y7nEtAe',
-                            timestamp: getNextDueTimestamp(),
-                            status: 'CHECKED_OUT',
-                            isFaulty: false,
-                            faultDescription: ''
-                        }
+                        items[0]
                     ],
                     email: 'neumannJ@msoe.edu',
                     major: 'Software Engineering'
@@ -141,8 +136,6 @@ describe('Checking an item out', function () {
             return app.client.getText('.toast');
         }).then(message => {
             assert.strictEqual(message, 'Checkout completed successfully!');
-            items[0].status === 'CHECKED_OUT';
-            items[0].timestamp = getNextDueTimestamp();
             return app.client.elements('#student .student .equipment .item-info');
         }).then(items => {
             assert.lengthOf(items.value, 1);
@@ -215,6 +208,10 @@ describe('Checking an item out', function () {
               status: 'success'
           }
       });
+      items[1].status = 'CHECKED_OUT';
+      items[1].timestamp = getNextDueTimestamp();
+      items[3].status = 'CHECKED_OUT';
+      items[3].timestamp = getNextDueTimestamp();
       mockServer.expect({
           method: 'get',
           endpoint: 'student',
@@ -259,10 +256,6 @@ describe('Checking an item out', function () {
           return app.client.getText('.toast');
       }).then(message => {
           assert.strictEqual(message, "Checkout completed successfully!");
-          items[1].status = 'CHECKED_OUT';
-          items[1].timestamp = getNextDueTimestamp();
-          items[3].status = 'CHECKED_OUT';
-          items[3].timestamp = getNextDueTimestamp();
           return app.client.elements('#student .student .equipment .item-info');
       }).then(items => {
           assert.lengthOf(items.value, 3);

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -69,7 +69,6 @@ describe('Checking an item out', function () {
     });
 
     it('checks out the item', () => {
-
         mockServer.expect({
             method: 'get',
             endpoint: 'item',
@@ -87,7 +86,6 @@ describe('Checking an item out', function () {
                 }
            }
         });
-
         mockServer.expect({
             method: 'post',
             endpoint: 'checkout',
@@ -100,7 +98,6 @@ describe('Checking an item out', function () {
                 status: 'success'
             }
         });
-
         mockServer.expect({
             method: 'get',
             endpoint: 'student',

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -2,6 +2,8 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import models from '../test-cases/models';
+import students from '../test-cases/students';
 
 describe('Checking an item out', function () {
 
@@ -40,14 +42,7 @@ describe('Checking an item out', function () {
             },
             response: {
                 status: 'success',
-                data: {
-                    id: 123456,
-                    name: 'John von Neumann',
-                    status: 'C - Current',
-                    email: 'neumannJ@msoe.edu',
-                    major: 'Software Engineering',
-                    items: []
-                }
+                data: students[0]
             }
         });
         mockServer.expect({
@@ -56,23 +51,7 @@ describe('Checking an item out', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            name: 'Resistor',
-                            description: 'V = IR',
-                            manufacturer: 'Manufacturer',
-                            vendor: 'Mouzer',
-                            location: 'Shelf 14',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 10.5,
-                            count: 20,
-                            items: [
-                                'iGwEZUvfA'
-                            ]
-                        }
-                    ]
+                    models: models.slice(0, 2)
                 }
             }
         });

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -34,7 +34,7 @@ describe('Checking an item out', function () {
     it('navigates to the student page', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
                 id: '123456'
             },
@@ -52,7 +52,7 @@ describe('Checking an item out', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -93,7 +93,7 @@ describe('Checking an item out', function () {
 
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 address: 'iGwEZUvfA'
             },
@@ -111,7 +111,7 @@ describe('Checking an item out', function () {
 
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkout',
+            endpoint: 'checkout',
             json: {
                 adminCode: null,
                 studentId: '123456',
@@ -124,7 +124,7 @@ describe('Checking an item out', function () {
 
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
               id: '123456'
             },
@@ -146,8 +146,6 @@ describe('Checking an item out', function () {
                 }
             }
         });
-
-
         return app.client.waitForVisible('.cart input[type="text"]').then(() => {
             return app.client.click('.cart input[type="text"]');
         }).then(() => {
@@ -180,7 +178,7 @@ describe('Checking an item out', function () {
     it("fails to checkout an item that's already checked out", () => {
       mockServer.expect({
           method: 'get',
-          endpoint: '/api/item',
+          endpoint: 'item',
           qs: {
               address: 'iGwEZVHHE'
           },
@@ -195,7 +193,6 @@ describe('Checking an item out', function () {
               }
          }
      });
-
      return app.client.setValue('.cart input[type="text"]','iGwEZVHHE').then(() => {
           return app.client.waitForVisible('#app .modal .modal-content');
       }).then(() => {
@@ -212,7 +209,7 @@ describe('Checking an item out', function () {
     it("can check out multiple items at once.", () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 address: 'iGwEZVeaT'
             },
@@ -230,7 +227,7 @@ describe('Checking an item out', function () {
 
        mockServer.expect({
            method: 'get',
-           endpoint: '/api/item',
+           endpoint: 'item',
            qs: {
                address: 'iGwEZVHHE'
            },
@@ -248,7 +245,7 @@ describe('Checking an item out', function () {
 
       mockServer.expect({
           method: 'post',
-          endpoint: '/api/checkout',
+          endpoint: 'checkout',
           json: {
               adminCode: null,
               studentId: '123456',
@@ -261,7 +258,7 @@ describe('Checking an item out', function () {
 
       mockServer.expect({
           method: 'get',
-          endpoint: '/api/student',
+          endpoint: 'student',
           qs: {
             id: '123456'
           },
@@ -338,10 +335,9 @@ describe('Checking an item out', function () {
     });
 
     it("doesn't allow the same items to be added to the cart twice", () => {
-
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 address: 'iGwEZUvfA'
             },
@@ -354,27 +350,25 @@ describe('Checking an item out', function () {
                     isFaulty: false,
                     faultDescription: ''
                 }
-           }
-       });
-
-       mockServer.expect({
-           method: 'get',
-           endpoint: '/api/item',
-           qs: {
-               address: 'iGwEZUvfA'
-           },
-           response:{
-               status: 'success',
-               data: {
-                   address: 'iGwEZUvfA',
-                   modelAddress: 'm8y7nEtAe',
-                   status: 'AVAILABLE',
-                   isFaulty: false,
-                   faultDescription: ''
-               }
-          }
-      });
-
+            }
+        });
+        mockServer.expect({
+            method: 'get',
+            endpoint: 'item',
+            qs: {
+                address: 'iGwEZUvfA'
+            },
+            response:{
+                status: 'success',
+                data: {
+                    address: 'iGwEZUvfA',
+                    modelAddress: 'm8y7nEtAe',
+                    status: 'AVAILABLE',
+                    isFaulty: false,
+                    faultDescription: ''
+                }
+            }
+        });
         return app.client.waitForVisible('.cart input[type="text"]').then(() => {
             return app.client.click('.cart input[type="text"]');
         }).then(() => {
@@ -392,6 +386,6 @@ describe('Checking an item out', function () {
             mockServer.validate();
             return app.client.waitForExist("#app .modal", 100, true);
         });
-    })
+    });
 
 });

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -96,6 +96,7 @@ describe('Checking an item out', function () {
         });
         items[0].status = 'CHECKED_OUT';
         items[0].timestamp = getNextDueTimestamp();
+        students[0].items.push(items[0]);
         mockServer.expect({
             method: 'get',
             endpoint: 'student',
@@ -104,16 +105,7 @@ describe('Checking an item out', function () {
             },
             response: {
                 status: 'success',
-                data: {
-                    id: 123456,
-                    name: 'John von Neumann',
-                    status: 'C - Current',
-                    items: [
-                        items[0]
-                    ],
-                    email: 'neumannJ@msoe.edu',
-                    major: 'Software Engineering'
-                }
+                data: students[0]
             }
         });
         return app.client.waitForVisible('.cart input[type="text"]').then(() => {
@@ -212,6 +204,8 @@ describe('Checking an item out', function () {
       items[1].timestamp = getNextDueTimestamp();
       items[3].status = 'CHECKED_OUT';
       items[3].timestamp = getNextDueTimestamp();
+      students[0].items.push(items[1]);
+      students[0].items.push(items[3]);
       mockServer.expect({
           method: 'get',
           endpoint: 'student',
@@ -220,18 +214,7 @@ describe('Checking an item out', function () {
           },
           response: {
               status: 'success',
-              data: {
-                  id: 123456,
-                  name: 'John von Neumann',
-                  status: 'C - Current',
-                  items: [
-                      items[0],
-                      items[1],
-                      items[3]
-                  ],
-                  email: 'neumannJ@msoe.edu',
-                  major: 'Software Engineering'
-              }
+              data: students[0]
           }
       });
       return app.client.waitForVisible('.cart input[type="text"]').then(() => {

--- a/test/functional/student-lookup.js
+++ b/test/functional/student-lookup.js
@@ -34,7 +34,7 @@ describe('Student Lookup', function () {
     it('Looks up a student', () => {
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
                 id: '123456'
             },
@@ -58,7 +58,7 @@ describe('Student Lookup', function () {
         });
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {
@@ -105,7 +105,7 @@ describe('Student Lookup', function () {
     it("Displays if an item is overdue", () => {
       mockServer.expect({
           method: 'get',
-          endpoint: '/api/student',
+          endpoint: 'student',
           qs: {
               id: '111111'
           },
@@ -152,7 +152,7 @@ describe('Student Lookup', function () {
     it("Displays message if student has no items", () => {
       mockServer.expect({
           method: 'get',
-          endpoint: '/api/student',
+          endpoint: 'student',
           qs: {
               id: '112994'
           },
@@ -189,7 +189,7 @@ describe('Student Lookup', function () {
     it("Pops an error modal if the student ID doesn't exist", () => {
       mockServer.expect({
           method: 'get',
-          endpoint: '/api/student',
+          endpoint: 'student',
           qs: {
               id: '000000'
           },

--- a/test/functional/student-lookup.js
+++ b/test/functional/student-lookup.js
@@ -2,6 +2,8 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import models from '../test-cases/models';
+import students from '../test-cases/students';
 
 describe('Student Lookup', function () {
 
@@ -40,20 +42,7 @@ describe('Student Lookup', function () {
             },
             response: {
                 status: 'success',
-                data: {
-                    id: 123456,
-                    name: 'John von Neumann',
-                    status: 'C - Current',
-                    items: [
-                        {
-                            address: 'iGwEZUvfA',
-                            modelAddress: 'm8y7nEtAe',
-                            timestamp: Math.floor(Date.now() / 1000) + 1000000000
-                        }
-                    ],
-                    email: 'vonneumann@msoe.edu',
-                    major: 'Chemical Engineering & Mathematics'
-                }
+                data: students[0]
             }
         });
         mockServer.expect({
@@ -63,21 +52,8 @@ describe('Student Lookup', function () {
                 status: 'success',
                 data: {
                     models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            name: 'Resistor',
-                            description: 'V = IR',
-                            manufacturer: 'Manufacturer',
-                            vendor: 'Mouzer',
-                            location: 'Shelf 14',
-                            isFaulty: false,
-                            faultDescription: '',
-                            price: 10.5,
-                            count: 20,
-                            items: [
-                                'iGwEZUvfA'
-                            ]
-                        }
+                        models[0],
+                        models[1]
                     ]
                 }
             }
@@ -93,12 +69,7 @@ describe('Student Lookup', function () {
             assert.strictEqual(id, '123456');
             return app.client.elements('#student .student .equipment .item-info');
         }).then(items => {
-            assert.lengthOf(items.value, 1);
-            return app.client.getText('#student .student .equipment .item-info');
-        }).then(item => {
-            assert.include(item, 'Resistor');
-            assert.include(item, 'iGwEZUvfA');
-            mockServer.validate();
+            assert.lengthOf(items.value, 0);
         });
     });
 
@@ -111,20 +82,7 @@ describe('Student Lookup', function () {
           },
           response: {
               status: 'success',
-              data: {
-                  id: 111111,
-                  name: 'Boaty McBoatface',
-                  status: 'C - Current',
-                  items: [
-                      {
-                          address: 'iGwEZUvfA',
-                          modelAddress: 'm8y7nEtAe',
-                          timestamp: 0
-                      }
-                  ],
-                  email: 'vonneumann@msoe.edu',
-                  major: 'Chemical Engineering & Mathematics'
-              }
+              data: students[1]
           }
       });
       return app.client.click("#omnibar").then(() => {
@@ -143,8 +101,8 @@ describe('Student Lookup', function () {
           assert.lengthOf(items.value, 1);
           return app.client.getText('#student .student .equipment .overdue');
       }).then(item => {
-          assert.include(item, 'Resistor');
-          assert.include(item, 'iGwEZUvfA');
+          assert.include(item, 'Transistor');
+          assert.include(item, 'iGwEZVeaT');
           mockServer.validate();
       });
     });
@@ -154,31 +112,24 @@ describe('Student Lookup', function () {
           method: 'get',
           endpoint: 'student',
           qs: {
-              id: '112994'
+              id: '123456'
           },
           response: {
               status: 'success',
-              data: {
-                  id: 112994,
-                  name: 'Ms Steak',
-                  status: 'C - Current',
-                  items: [],
-                  email: 'vonneumann@msoe.edu',
-                  major: 'Chemical Engineering & Mathematics'
-              }
+              data: students[0]
           }
       });
       return app.client.click("#omnibar").then(() => {
-        return app.client.keys('112994');
+        return app.client.keys('123456');
       }).then(() => {
           return app.client.waitForVisible('#student', 1000000);
       }).then(() => {
           return app.client.getText('#student .student .name');
       }).then(name => {
-          assert.strictEqual(name, 'Ms Steak');
+          assert.strictEqual(name, students[0].name);
           return app.client.getText('#student .student .id');
       }).then(id => {
-          assert.strictEqual(id, '112994');
+          assert.strictEqual(id, '123456');
           return app.client.getText('#student .student .equipment-none');
       }).then(message => {
           assert.strictEqual(message, "Student has no equipment checked out.");
@@ -191,16 +142,15 @@ describe('Student Lookup', function () {
           method: 'get',
           endpoint: 'student',
           qs: {
-              id: '000000'
+              id: '314159'
           },
           response: {
               status: 'failure',
-              message: 'An invalid student ID was scanned. The student could not be found.'
+              message: 'The student could not be found.'
           }
       });
-
       return app.client.click("#omnibar").then(() => {
-        return app.client.keys("000000");
+        return app.client.keys("314159");
       }).then(() => {
           return app.client.waitForVisible('#app .modal', 1000000);
       }).then(() => {

--- a/test/functional/student-lookup.js
+++ b/test/functional/student-lookup.js
@@ -51,10 +51,7 @@ describe('Student Lookup', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        models[0],
-                        models[1]
-                    ]
+                    models
                 }
             }
         });

--- a/test/functional/view-models.js
+++ b/test/functional/view-models.js
@@ -2,6 +2,7 @@ import { Application } from 'spectron';
 import electron from 'electron-prebuilt';
 import { assert } from 'chai';
 import MockServer from '../util/mock-server';
+import models from '../test-cases/models';
 
 describe('View all models', function () {
 
@@ -24,7 +25,7 @@ describe('View all models', function () {
     });
 
     it('shows a list of all models', () => {
-        let models;
+        let modelList;
         mockServer.expect({
             method: 'get',
             endpoint: 'model/all',
@@ -32,31 +33,8 @@ describe('View all models', function () {
                 status: 'success',
                 data: {
                     models: [
-                        {
-                            address: 'm8y7nEtAe',
-                            count: 20,
-                            description: 'V = IR',
-                            faultDescription: '',
-                            isFaulty: false,
-                            items: [ 'iGwEXUvfA', 'iGwEZVHHE', 'iGwEZVeaT' ],
-                            location: 'Shelf 14',
-                            manufacturer: "Pancakes R' Us",
-                            name: 'Resistor',
-                            price: 10.5,
-                            vendor: 'Mouzer'
-                        }, {
-                            address: 'm8y7nFLsT',
-                            count: 10,
-                            description: 'Something used in computers',
-                            faultDescription: '',
-                            isFaulty: false,
-                            items: [],
-                            location: 'Shelf 2',
-                            manufacturer: 'Vroom Industries',
-                            name: 'Transistor',
-                            price: 4,
-                            vendor: 'Fankserrogatoman Inc'
-                        }
+                        models[0],
+                        models[1]
                     ]
                 }
             }
@@ -69,18 +47,18 @@ describe('View all models', function () {
             assert.match(headerTxt, /All models/);
             return app.client.elements('#models .model');
         }).then(resp => {
-            models = resp.value;
-            assert.lengthOf(models, 2);
+            modelList = resp.value;
+            assert.lengthOf(modelList, 2);
             return app.client.getText('#models:first-child');
         }).then(model => {
             assert.include(model, 'Resistor');
             assert.include(model, 'm8y7nEtAe');
             assert.include(model, 'V = IR');
             return app.client.getText('#models .model:nth-of-type(1)');
-        }).then(models => {
-            assert.include(models[1], 'Transistor');
-            assert.include(models[1], 'm8y7nFLsT');
-            assert.include(models[1], 'Something used in computers');
+        }).then(modelList => {
+            assert.include(modelList[1], 'Transistor');
+            assert.include(modelList[1], 'm8y7nFLsT');
+            assert.include(modelList[1], 'Something used in computers');
             mockServer.validate();
         });
     });

--- a/test/functional/view-models.js
+++ b/test/functional/view-models.js
@@ -32,10 +32,7 @@ describe('View all models', function () {
             response: {
                 status: 'success',
                 data: {
-                    models: [
-                        models[0],
-                        models[1]
-                    ]
+                    models
                 }
             }
         });

--- a/test/functional/view-models.js
+++ b/test/functional/view-models.js
@@ -27,7 +27,7 @@ describe('View all models', function () {
         let models;
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             response: {
                 status: 'success',
                 data: {

--- a/test/test-cases/items.js
+++ b/test/test-cases/items.js
@@ -16,7 +16,7 @@ export default [
     {
         address: 'iGwEZVeaT',
         modelAddress: 'm8y7nFLsT',
-        status: 'AVAILABLE',
+        status: 'CHECKED_OUT',
         isFaulty: false,
         faultDescription: ''
     },

--- a/test/test-cases/items.js
+++ b/test/test-cases/items.js
@@ -18,7 +18,8 @@ export default [
         modelAddress: 'm8y7nFLsT',
         status: 'CHECKED_OUT',
         isFaulty: false,
-        faultDescription: ''
+        faultDescription: '',
+        timestamp: 0
     },
     {
         address: 'iGwEZVvgu',

--- a/test/test-cases/items.js
+++ b/test/test-cases/items.js
@@ -1,0 +1,30 @@
+export default [
+    {
+        address: 'iGwEZUvfA',
+        modelAddress: 'm8y7nEtAe',
+        status: 'AVAILABLE',
+        isFaulty: false,
+        faultDescription: ''
+    },
+    {
+        address: 'iGwEZVHHE',
+        modelAddress: 'm8y7nFLsT',
+        status: 'AVAILABLE',
+        isFaulty: false,
+        faultDescription: ''
+    },
+    {
+        address: 'iGwEZVeaT',
+        modelAddress: 'm8y7nFLsT',
+        status: 'AVAILABLE',
+        isFaulty: false,
+        faultDescription: ''
+    },
+    {
+        address: 'iGwEZVvgu',
+        modelAddress: 'm8y7nEtAe',
+        status: 'AVAILABLE',
+        isFaulty: false,
+        faultDescription: ''
+    }
+]

--- a/test/test-cases/items.js
+++ b/test/test-cases/items.js
@@ -26,5 +26,19 @@ export default [
         status: 'AVAILABLE',
         isFaulty: false,
         faultDescription: ''
+    },
+    {
+        address: 'iGwEZW6nn',
+        modelAddress: 'm8y7nFLsT',
+        status: 'AVAILABLE',
+        isFaulty: false,
+        faultDescription: ''
+    },
+    {
+        address: 'iGwEZWXhn',
+        modelAddress: 'm8y7nFLsT',
+        status: 'AVAILABLE',
+        isFaulty: false,
+        faultDescription: ''
     }
 ]

--- a/test/test-cases/models.js
+++ b/test/test-cases/models.js
@@ -1,0 +1,32 @@
+export default [
+    {
+        address: 'm8y7nEtAe',
+        name: 'Resistor',
+        description: 'V = IR',
+        manufacturer: 'Pancakes R\' Us',
+        vendor: 'Mouzer',
+        location: 'Shelf 14',
+        isFaulty: false,
+        faultDescription: '',
+        price: 10.5,
+        count: 20,
+        items: [
+            'iGwEZUvfA',
+            'iGwEZVHHE',
+            'iGwEZVeaT'
+        ]
+    },
+    {
+        address: 'm8y7nFLsT',
+        name: 'Transistor',
+        description: 'Something used in computers',
+        manufacturer: 'Vroom Industries',
+        vendor: 'Fankserrogatoman Inc',
+        location: 'Shelf 2',
+        isFaulty: false,
+        faultDescription: '',
+        price: 4,
+        count: 10,
+        items: []
+    }
+]

--- a/test/test-cases/students.js
+++ b/test/test-cases/students.js
@@ -1,0 +1,10 @@
+export default [
+    {
+        id: 123456,
+        name: 'John von Neumann',
+        status: 'C - Current',
+        email: 'neumannJ@msoe.edu',
+        major: 'Software Engineering',
+        items: []
+    }
+]

--- a/test/test-cases/students.js
+++ b/test/test-cases/students.js
@@ -1,3 +1,5 @@
+import items from './items';
+
 export default [
     {
         id: 123456,
@@ -13,12 +15,6 @@ export default [
         status: 'C - Current',
         email: 'mcboatfaceb@msoe.edu',
         major: 'Hyperdimensional Nautical Machines Engineering',
-        items: [
-            {
-                address: 'iGwEZVeaT',
-                modelAddress: 'm8y7nFLsT',
-                timestamp: 0
-            }
-        ]
+        items: [items[2]]
     }
 ]

--- a/test/test-cases/students.js
+++ b/test/test-cases/students.js
@@ -6,5 +6,19 @@ export default [
         email: 'neumannJ@msoe.edu',
         major: 'Software Engineering',
         items: []
+    },
+    {
+        id: 111111,
+        name: 'Boaty McBoatface',
+        status: 'C - Current',
+        email: 'mcboatfaceb@msoe.edu',
+        major: 'Hyperdimensional Nautical Machines Engineering',
+        items: [
+            {
+                address: 'iGwEZVeaT',
+                modelAddress: 'm8y7nFLsT',
+                timestamp: 0
+            }
+        ]
     }
 ]

--- a/test/unit/lib/api-client.js
+++ b/test/unit/lib/api-client.js
@@ -49,7 +49,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkin',
+            endpoint: 'checkin',
             json: {
                 studentId: '123456',
                 itemAddress: 'iGwEZUvfA'
@@ -68,7 +68,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkout',
+            endpoint: 'checkout',
             json: {
                 studentId: '123456',
                 itemAddresses: ['iGwEZUvfA', 'iGwEZVHHE']
@@ -87,7 +87,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/checkout',
+            endpoint: 'checkout',
             json: {
                 studentId: '123456',
                 itemAddresses: ['iGwEZUvfA', 'iGwEZVHHE'],
@@ -111,7 +111,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/item',
+            endpoint: 'item',
             json: {
                 modelAddress: 'm8y7nEtAe'
             },
@@ -141,7 +141,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/model',
+            endpoint: 'model',
             json: {
                 name: 'Resistor',
                 description: 'V = IR',
@@ -175,7 +175,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'delete',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 itemAddress: 'iGwEZUvfA',
                 modelAddress: 'm8y7nEtAe'
@@ -204,7 +204,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item/all',
+            endpoint: 'item/all',
             qs: {},
             response
         });
@@ -234,7 +234,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model/all',
+            endpoint: 'model/all',
             qs: {},
             response
         });
@@ -257,7 +257,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item/overdue',
+            endpoint: 'item/overdue',
             response
         });
         return getOverdueItems().then(data => {
@@ -279,7 +279,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/item',
+            endpoint: 'item',
             qs: {
                 address: 'iGwEZUvfA'
             },
@@ -311,7 +311,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/model',
+            endpoint: 'model',
             qs: {
                 address: 'm8y7nEtAe'
             },
@@ -343,7 +343,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'delete',
-            endpoint: '/api/model',
+            endpoint: 'model',
             qs: {
                 modelAddress: 'm8y7nEtAe'
             },
@@ -368,7 +368,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'get',
-            endpoint: '/api/student',
+            endpoint: 'student',
             qs: {
                 id: '123456'
             },
@@ -386,7 +386,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'post',
-            endpoint: '/api/student',
+            endpoint: 'student',
             json: {
                 data: '123456'
             },
@@ -417,7 +417,7 @@ describe('API Client', () => {
         };
         mockServer.expect({
             method: 'patch',
-            endpoint: '/api/model',
+            endpoint: 'model',
             qs: {
                 address: 'm8y7nEtAe'
             },

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -67,6 +67,10 @@ export default class MockServer {
                     try {
                         assert.deepEqual(data, response);
                     } catch (e) {
+                        console.log('Expected response:');
+                        console.log(JSON.stringify(response, null, 4));
+                        console.log('Actual response:');
+                        console.log(JSON.stringify(data, null, 4));
                         response = {
                             status: 'failure',
                             message: 'Unexpected response'

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -69,15 +69,9 @@ export default class MockServer {
                     }
                     console.log(endpoint);
                     try {
-                        assert.deepEqual(serverResponse, response);
+                        assert.deepEqual(response, serverResponse);
                     } catch (e) {
-                        console.log(JSON.stringify(changesets.diff(serverResponse, response), null, 2));
-                        console.log(serverResponse);
-                        console.log(response);
-                        response = {
-                            status: 'failure',
-                            message: 'Unexpected response'
-                        };
+                        console.log(JSON.stringify(changesets.diff(response, serverResponse), null, 2));
                     }
                     res.json(response);
                 });

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -2,7 +2,6 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import { assert } from 'chai';
 import { changePort, call } from '../../.dist/lib/api-client';
-import changesets from 'diff-json';
 import clone from 'consus-core/clone';
 
 const OFF = 0;
@@ -68,12 +67,7 @@ export default class MockServer {
                     if (data !== undefined) {
                         serverResponse.data = data;
                     }
-                    console.log(endpoint);
-                    try {
-                        assert.deepEqual(response, serverResponse);
-                    } catch (e) {
-                        console.log(JSON.stringify(changesets.diff(response, serverResponse), null, 2));
-                    }
+                    assert.deepEqual(response, serverResponse);
                     res.json(response);
                 }).catch(message => {
                     let serverResponse = {
@@ -82,12 +76,7 @@ export default class MockServer {
                     if (message !== undefined) {
                         serverResponse.message = message;
                     }
-                    console.log(endpoint);
-                    try {
-                        assert.deepEqual(response, serverResponse);
-                    } catch (e) {
-                        console.log(JSON.stringify(changesets.diff(response, serverResponse), null, 2));
-                    }
+                    assert.deepEqual(response, serverResponse);
                     res.json(response);
                 });
             });

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -61,15 +61,19 @@ export default class MockServer {
                 }
                 endpoint = endpoint.substring(5);
                 call(endpoint, method, qs, json).then(data => {
-                    data = {
-                        status: 'success',
-                        data
+                    let serverResponse = {
+                        status: 'success'
                     };
+                    if (data !== undefined) {
+                        serverResponse.data = data;
+                    }
                     console.log(endpoint);
                     try {
-                        assert.deepEqual(data, response);
+                        assert.deepEqual(serverResponse, response);
                     } catch (e) {
-                        console.log(JSON.stringify(changesets.diff(data, response), null, 2));
+                        console.log(JSON.stringify(changesets.diff(serverResponse, response), null, 2));
+                        console.log(serverResponse);
+                        console.log(response);
                         response = {
                             status: 'failure',
                             message: 'Unexpected response'

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import { assert } from 'chai';
 import { changePort, call } from '../../.dist/lib/api-client';
 import changesets from 'diff-json';
+import clone from 'consus-core/clone';
 
 const OFF = 0;
 const STARTING = 1;
@@ -90,7 +91,7 @@ export default class MockServer {
         call.qs = call.qs || {};
         call.endpoint = '/api/' + call.endpoint;
         assert.isObject(call.response, 'Call response must be an object.');
-        this.expectedCalls.push(call);
+        this.expectedCalls.push(clone(call));
     }
 
     validate() {

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import { assert } from 'chai';
 import { changePort, call } from '../../.dist/lib/api-client';
+import changesets from 'diff-json';
 
 const OFF = 0;
 const STARTING = 1;
@@ -64,13 +65,11 @@ export default class MockServer {
                         status: 'success',
                         data
                     };
+                    console.log(endpoint);
                     try {
                         assert.deepEqual(data, response);
                     } catch (e) {
-                        console.log('Expected response:');
-                        console.log(JSON.stringify(response, null, 4));
-                        console.log('Actual response:');
-                        console.log(JSON.stringify(data, null, 4));
+                        console.log(JSON.stringify(changesets.diff(data, response), null, 2));
                         response = {
                             status: 'failure',
                             message: 'Unexpected response'

--- a/test/util/mock-server.js
+++ b/test/util/mock-server.js
@@ -75,6 +75,20 @@ export default class MockServer {
                         console.log(JSON.stringify(changesets.diff(response, serverResponse), null, 2));
                     }
                     res.json(response);
+                }).catch(message => {
+                    let serverResponse = {
+                        status: 'failure'
+                    };
+                    if (message !== undefined) {
+                        serverResponse.message = message;
+                    }
+                    console.log(endpoint);
+                    try {
+                        assert.deepEqual(response, serverResponse);
+                    } catch (e) {
+                        console.log(JSON.stringify(changesets.diff(response, serverResponse), null, 2));
+                    }
+                    res.json(response);
                 });
             });
             this.server = app.listen(port || 80, () => {


### PR DESCRIPTION
### Summary

This PR updates all client functional tests to be runnable as integration tests.

Sister PRs (merge **this** PR second!):
* TheFourFifths/consus/pull/69 (merge first!)
* TheFourFifths/consus-integration/pull/2 (merge last!)

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Check out the `functional-integration-TFF-170` branch on `consus`
2. `npm install -g` in `consus`
3. `consusd start --port=8081` anywhere
4. Check out the `functional-integration-TFF-170` branch on `consus-client`
5. `npm install` in `consus-client`
6. `npm run integration-test` in `consus-client`
7. `consusd stop` anywhere
8. Verify that all tests pass

### Links

- [TFF-29](https://msoese.atlassian.net/browse/TFF-29)
- TheFourFifths/consus-integration/pull/2
- TheFourFifths/consus/pull/69
