### PR TITLE
[TFF-226] Refactor model data

### DIFF
--- a/src/controllers/components/cart-panel.js
+++ b/src/controllers/components/cart-panel.js
@@ -64,11 +64,11 @@ export default class CartController {
         });
     }
 
-    static throwError(error){
+    static throwError(error) {
         Dispatcher.handleAction("ERROR", { error });
     }
 
-    static turnInLostEquipment(equipmentAddress){
+    static turnInLostEquipment(equipmentAddress) {
         let result = readAddress(equipmentAddress);
         if (result.type === 'model' ) {
             //this is where checkin for model logic would go
@@ -85,21 +85,20 @@ export default class CartController {
         }
     }
 
-    static changeIsLongterm(isLongterm){
+    static changeIsLongterm(isLongterm) {
         Dispatcher.handleAction('EDIT_IS_LONGTERM', {
             isLongterm
         });
     }
-    static changeLongtermDate(dueDate){
+    static changeLongtermDate(dueDate) {
         Dispatcher.handleAction('EDIT_LONGTERM_DUEDATE', {
             dueDate
         });
     }
 
-    static changeLongtermProfessor(professor){
+    static changeLongtermProfessor(professor) {
         Dispatcher.handleAction('EDIT_LONGTERM_PROFESSOR', {
             professor
         });
     }
 }
-

--- a/src/controllers/components/create-item-form.js
+++ b/src/controllers/components/create-item-form.js
@@ -13,7 +13,7 @@ export default class ItemFormController {
         });
     }
 
-    static popNoModelSelectedToast(){
+    static popNoModelSelectedToast() {
         Dispatcher.handleAction('CREATE_TOAST', {
             text: 'Please select a model.'
         });

--- a/src/controllers/components/create-model-form.js
+++ b/src/controllers/components/create-model-form.js
@@ -3,6 +3,7 @@ import { hashHistory } from 'react-router';
 import { Dispatcher } from 'consus-core/flux';
 
 export default class ModelFormController {
+
     static createModel(name, description, manufacturer, vendor, location, allowCheckout, price, count) {
         return createModel(name, description, manufacturer, vendor, location, allowCheckout, parseFloat(price), parseInt(count)).then(model => {
             Dispatcher.handleAction("MODEL_CREATED", model);
@@ -31,4 +32,5 @@ export default class ModelFormController {
             });
         });
     }
+
 }

--- a/src/controllers/components/item.js
+++ b/src/controllers/components/item.js
@@ -3,7 +3,7 @@ import { Dispatcher } from 'consus-core/flux';
 
 export default class ItemController {
 
-    static deleteItem(item){
+    static deleteItem(item) {
         return deleteItem(item).then(data => {
             Dispatcher.handleAction('ITEMS_RECEIVED', data);
             Dispatcher.handleAction('CREATE_TOAST', {

--- a/src/controllers/components/model.js
+++ b/src/controllers/components/model.js
@@ -2,6 +2,7 @@ import { searchModel, deleteModel, getAllModels, createItem } from '../../lib/ap
 import { Dispatcher } from 'consus-core/flux';
 
 export default class ModelController {
+
     static getModel(address) {
         return searchModel(address).then( model => {
             Dispatcher.handleAction('MODEL_FOUND', model);
@@ -37,4 +38,5 @@ export default class ModelController {
             });
         });
     }
+
 }

--- a/src/controllers/components/omnibar.js
+++ b/src/controllers/components/omnibar.js
@@ -112,4 +112,5 @@ export default class OmnibarController {
         }
         return true;
     }
+
 }

--- a/src/controllers/components/student-file-upload-form.js
+++ b/src/controllers/components/student-file-upload-form.js
@@ -1,5 +1,6 @@
 import { uploadStudents } from '../../lib/api-client';
 import { Dispatcher } from 'consus-core/flux';
+
 export default class StudentFileUploadFormController {
 
     static uploadStudents(file){

--- a/src/controllers/components/student-panel.js
+++ b/src/controllers/components/student-panel.js
@@ -1,8 +1,8 @@
 import { getAllModels } from '../../lib/api-client';
 import { Dispatcher } from 'consus-core/flux';
 
+export default class StudentPanelController {
 
-export default class StudentPanelController{
     static getModels() {
         return getAllModels().then(models => {
             Dispatcher.handleAction("MODELS_RECEIVED", models);
@@ -31,4 +31,5 @@ export default class StudentPanelController{
             error: "Input was not a number"
         });
     }
+
 }

--- a/src/controllers/components/student.js
+++ b/src/controllers/components/student.js
@@ -1,11 +1,11 @@
 import { Dispatcher } from 'consus-core/flux';
-import { updateStudent } from '../../lib/api-client';
+import { updateStudent as apiUpdateStudent } from '../../lib/api-client';
 
 export default class StudentController {
 
-    static UpdateStudent(student) {
+    static updateStudent(student) {
         delete student.hasOverdueItem;
-        return updateStudent(student).then(student => {
+        return apiUpdateStudent(student).then(student => {
             Dispatcher.handleAction("STUDENT_UPDATED", student);
         });
     }

--- a/src/controllers/components/student.js
+++ b/src/controllers/components/student.js
@@ -1,11 +1,13 @@
 import { Dispatcher } from 'consus-core/flux';
 import { updateStudent } from '../../lib/api-client';
 
-export default class StudentController{
-    static UpdateStudent(student){
+export default class StudentController {
+
+    static UpdateStudent(student) {
         delete student.hasOverdueItem;
         return updateStudent(student).then(student => {
             Dispatcher.handleAction("STUDENT_UPDATED", student);
         });
     }
+
 }

--- a/src/controllers/components/toasts.js
+++ b/src/controllers/components/toasts.js
@@ -1,9 +1,11 @@
 import { Dispatcher } from 'consus-core/flux';
 
-export default class ToastsController{
-    static popToast(id){
+export default class ToastsController {
+
+    static popToast(id) {
         Dispatcher.handleAction('POP_TOAST', {
             id
         });
     }
+
 }

--- a/src/controllers/pages/index.js
+++ b/src/controllers/pages/index.js
@@ -3,6 +3,7 @@ import { Dispatcher } from 'consus-core/flux';
 import { hashHistory } from 'react-router';
 
 export default class IndexController {
+
     static getItems() {
         return getAllItems().then(items => {
             Dispatcher.handleAction('ITEMS_RECEIVED', items);
@@ -25,10 +26,11 @@ export default class IndexController {
         });
     }
 
-    static getStudents(){
+    static getStudents() {
         return getAllModels().then(models => {
             Dispatcher.handleAction("MODELS_RECEIVED", models);
             hashHistory.push('/students');
         });
     }
+
 }

--- a/src/controllers/pages/items.js
+++ b/src/controllers/pages/items.js
@@ -3,10 +3,12 @@ import { Dispatcher } from 'consus-core/flux';
 import { hashHistory } from 'react-router';
 
 export default class ItemController {
+
     static newItemPage() {
         return getAllModels().then(models => {
             Dispatcher.handleAction("MODELS_RECEIVED", models);
             hashHistory.push('/items/new');
         });
     }
+
 }

--- a/src/controllers/pages/model.js
+++ b/src/controllers/pages/model.js
@@ -13,4 +13,5 @@ export default class ModelController {
             Dispatcher.handleAction("ERROR", { error: 'The model requested does not exist' });
         });
     }
+
 }

--- a/src/controllers/pages/overdue.js
+++ b/src/controllers/pages/overdue.js
@@ -2,9 +2,11 @@ import { getOverdueItems } from '../../lib/api-client';
 import { Dispatcher } from 'consus-core/flux';
 
 export default class OverdueItemsController {
+
     static getOverdueItems() {
         return getOverdueItems().then(items => {
             Dispatcher.handleAction("OVERDUE_ITEMS_RECEIVED", items);
         });
     }
+
 }

--- a/src/controllers/pages/student.js
+++ b/src/controllers/pages/student.js
@@ -20,8 +20,7 @@ export default class StudentController {
     }
 
     static checkout(id, equipment) {
-        let equipmentAddresses = this.pushEquipment(equipment);
-        return checkOutContents(id, equipmentAddresses, AuthStore.getAdminCode()).then(() => {
+        return checkOutContents(id, equipment, AuthStore.getAdminCode()).then(() => {
             return searchStudent(id).then(student => {
                 Dispatcher.handleAction('CHECKOUT_SUCCESS');
                 Dispatcher.handleAction("STUDENT_FOUND", student);
@@ -37,21 +36,6 @@ export default class StudentController {
                 });
             }
         });
-    }
-    static pushEquipment(equipment) {
-        let equipmentAddresses = [];
-        if (equipment) {
-            equipment.forEach(e => {
-                if(e.quantity){
-                    for (let i = 0; i < e.quantity; i++){
-                        equipmentAddresses.push(e.address);
-                    }
-                } else {
-                    equipmentAddresses.push(e.address);
-                }
-            });
-        }
-        return equipmentAddresses;
     }
 
     static checkInModel(id, modelAddress, quantity) {
@@ -74,8 +58,7 @@ export default class StudentController {
     static longtermCheckout(id, equipment, dueDate, professor) {
 
         if(this.isValidLongtermData(dueDate, professor)){
-            let equipmentAddresses = this.pushEquipment(equipment);
-            return checkOutContentsLongterm(id, equipmentAddresses, dueDate, professor, AuthStore.getAdminCode()).then(() => {
+            return checkOutContentsLongterm(id, equipment, dueDate, professor, AuthStore.getAdminCode()).then(() => {
                 return searchStudent(id).then(student => {
                     Dispatcher.handleAction('CHECKOUT_SUCCESS');
                     Dispatcher.handleAction("STUDENT_FOUND", student);
@@ -103,7 +86,7 @@ export default class StudentController {
         }
         let today = moment();
         let dueDateMoment = moment.tz(dueDate, 'America/Chicago');
-        if(dueDateMoment.isBefore(today)){
+        if(!dueDateMoment.isAfter(today)){
             Dispatcher.handleAction('ERROR', {
                 error: 'Due date cannot be set to today or past.'
             });

--- a/src/controllers/pages/student.js
+++ b/src/controllers/pages/student.js
@@ -3,10 +3,12 @@ import { Dispatcher } from 'consus-core/flux';
 import AuthStore from '../../store/authentication-store';
 import moment from 'moment-timezone';
 
-export default class StudentController{
-    static acceptAdminModal(adminCode){
-        if (adminCode.length > 0)
+export default class StudentController {
+
+    static acceptAdminModal(adminCode) {
+        if (adminCode.length > 0) {
             Dispatcher.handleAction("ADMIN_CODE_ENTERED", {adminCode});
+        }
     }
 
     static cancelAdminModal() {
@@ -36,7 +38,7 @@ export default class StudentController{
             }
         });
     }
-    static pushEquipment(equipment){
+    static pushEquipment(equipment) {
         let equipmentAddresses = [];
         if (equipment) {
             equipment.forEach(e => {
@@ -52,7 +54,7 @@ export default class StudentController{
         return equipmentAddresses;
     }
 
-    static checkInModel(id, modelAddress, quantity){
+    static checkInModel(id, modelAddress, quantity) {
         return checkInModel(id, modelAddress, quantity).then(data => {
             return searchStudent(id).then(student => {
                 Dispatcher.handleAction('MODEL_CHECKIN_SUCCESS', {
@@ -69,7 +71,7 @@ export default class StudentController{
         });
     }
 
-    static longtermCheckout(id, equipment, dueDate, professor){
+    static longtermCheckout(id, equipment, dueDate, professor) {
 
         if(this.isValidLongtermData(dueDate, professor)){
             let equipmentAddresses = this.pushEquipment(equipment);
@@ -91,7 +93,8 @@ export default class StudentController{
             });
         }
     }
-    static isValidLongtermData(dueDate, professor){
+
+    static isValidLongtermData(dueDate, professor) {
         if(dueDate === undefined || dueDate === null){
             Dispatcher.handleAction('ERROR', {
                 error: 'Please enter a due date.'
@@ -114,9 +117,11 @@ export default class StudentController{
         }
         return true;
     }
+
     static throwNoItemsError() {
         Dispatcher.handleAction('ERROR', {
             error: 'No Items were scanned for checkout.'
         });
     }
+
 }

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -76,10 +76,10 @@ export function checkInModel(studentId, modelAddress, quantity){
     });
 }
 
-export function checkOutContents(studentId, equipmentAddresses, code){
+export function checkOutContents(studentId, equipment, code){
     let params = {
         studentId,
-        equipmentAddresses
+        equipment
     };
     if (typeof code !== 'undefined') {
         params.adminCode = code;
@@ -182,10 +182,10 @@ export function uploadStudents(data){
     });
 }
 
-export function checkOutContentsLongterm(studentId, equipmentAddresses, dueDate, professor, code){
+export function checkOutContentsLongterm(studentId, equipment, dueDate, professor, code){
     let params = {
         studentId,
-        equipmentAddresses,
+        equipment,
         dueDate,
         professor
     };

--- a/src/store/cart-store.js
+++ b/src/store/cart-store.js
@@ -77,8 +77,7 @@ store.registerHandler('CHECKOUT_ITEM_FOUND', data => {
         clearTimer();
     }
     let item = {
-        address: data.address,
-        status: data.status
+        address: data.address
     };
     contents.push(item);
     startTimer(store.TIMEOUT_TIME);

--- a/src/store/cart-store.js
+++ b/src/store/cart-store.js
@@ -1,6 +1,6 @@
 import { Store } from 'consus-core/flux';
 import StudentStore from './student-store';
-import {checkOutContents, checkOutContentsLongterm, searchStudent} from '../lib/api-client';
+import { checkOutContents, checkOutContentsLongterm, searchStudent } from '../lib/api-client';
 import StudentController from '../controllers/pages/student';
 import { Dispatcher } from 'consus-core/flux';
 
@@ -16,19 +16,19 @@ class CartStore extends Store {
         return contents;
     }
 
-    isOnTimeout(){
+    isOnTimeout() {
         return timer !== null;
     }
 
-    getIsLongterm(){
+    getIsLongterm() {
         return isLongterm;
     }
 
-    getProfessor(){
+    getProfessor() {
         return professor;
     }
 
-    getDueDate(){
+    getDueDate() {
         return dueDate;
     }
 
@@ -38,25 +38,23 @@ const store = new CartStore();
 
 function startTimer(period) {
     timer = setTimeout(() => {
-        if(store.getIsLongterm()){
-            if(StudentController.isValidLongtermData(store.getDueDate(), store.getProfessor())){
-                checkOutContentsLongterm(StudentStore.getStudent().id,
-                StudentController.pushEquipment(store.getContents()), store.getDueDate(), store.getProfessor()).then(() => {
+        if (store.getIsLongterm()) {
+            if (StudentController.isValidLongtermData(store.getDueDate(), store.getProfessor())) {
+                checkOutContentsLongterm(StudentStore.getStudent().id, contents, store.getDueDate(), store.getProfessor()).then(() => {
                     return searchStudent(StudentStore.getStudent().id).then(student => {
                         Dispatcher.handleAction('CHECKOUT_SUCCESS');
                         Dispatcher.handleAction("STUDENT_FOUND", student);
                     });
                 });
             }
-        }else{
-            checkOutContents(StudentStore.getStudent().id, contents.map(content => content.address)).then(() => {
+        } else {
+            checkOutContents(StudentStore.getStudent().id, contents).then(() => {
                 return searchStudent(StudentStore.getStudent().id).then(student => {
                     Dispatcher.handleAction('CHECKOUT_SUCCESS');
                     Dispatcher.handleAction("STUDENT_FOUND", student);
                 });
             });
         }
-
         clearTimer();
     }, period);
 }
@@ -126,18 +124,22 @@ store.registerHandler('CHECKOUT_SUCCESS', () => {
     isLongterm = false;
     store.emitChange();
 });
+
 store.registerHandler('EDIT_IS_LONGTERM', data => {
     isLongterm = data.isLongterm;
     store.emitChange();
 });
+
 store.registerHandler('EDIT_LONGTERM_DUEDATE', data => {
     dueDate = data.dueDate;
     store.emitChange();
 });
+
 store.registerHandler('EDIT_LONGTERM_PROFESSOR', data => {
     professor = data.professor;
     store.emitChange();
 });
+
 store.registerHandler('CLEAR_ALL_DATA', () => {
     contents = [];
     dueDate = null;

--- a/src/store/cart-store.js
+++ b/src/store/cart-store.js
@@ -11,6 +11,7 @@ let dueDate = null;
 let timer = null;
 
 class CartStore extends Store {
+
     getContents() {
         return contents;
     }
@@ -18,15 +19,19 @@ class CartStore extends Store {
     isOnTimeout(){
         return timer !== null;
     }
+
     getIsLongterm(){
         return isLongterm;
     }
+
     getProfessor(){
         return professor;
     }
+
     getDueDate(){
         return dueDate;
     }
+
 }
 
 const store = new CartStore();

--- a/src/store/student-store.js
+++ b/src/store/student-store.js
@@ -1,10 +1,11 @@
-import {Store} from 'consus-core/flux';
+import { Store } from 'consus-core/flux';
 import CartStore from './cart-store';
 
 let student = null;
 let students = {};
 
 class StudentStore extends Store {
+
     hasOverdueItems(items) {
         return items.some(element => {
             let now = Math.floor(Date.now() / 1000);
@@ -23,6 +24,7 @@ class StudentStore extends Store {
     getStudentById(studentId){
         return students[studentId];
     }
+
 }
 
 const store = new StudentStore();

--- a/src/views/components/student-panel.jsx
+++ b/src/views/components/student-panel.jsx
@@ -63,26 +63,27 @@ export default class StudentPanel extends ListenerComponent {
             return (<i className='equipment-none'>Student has no equipment checked out.</i>);
         }
 
-        let modelCounts = StudentPanelController.countDuplicateModels(this.props.student.models);
-
         return (
             <div className='equipment'>
                 {this.props.student.items.map((item, i) => {
-                    return (<Link to={`/item/${item.address}`}  key={i} className={item.timestamp < Math.floor(Date.now()/1000) ? 'link-nostyle overdue' : 'link-nostyle'}>
-                        <div className="item-info">
-                            {this.renderItemInfo(item)}
-                        </div>
-                    </Link>);
+                    return (
+                        <Link to={`/item/${item.address}`}  key={i} className={item.timestamp < Math.floor(Date.now()/1000) ? 'link-nostyle overdue' : 'link-nostyle'}>
+                            <div className="item-info">
+                                {this.renderItemInfo(item)}
+                            </div>
+                        </Link>
+                    );
                 })}
 
-                {modelCounts.map((model, m) => {
+                {this.props.student.models.map((model, i) => {
                     return (
-                        <div className="item-info" key={m}>
+                        <div className="item-info" key={i}>
                             <Link to={`/model/${model.address}`} className={model.timestamp < Math.floor(Date.now()/1000) ? 'link-nostyle overdue' : 'link-nostyle'}>
                                 {this.renderModelInfo(model)}
                             </Link>
                             {this.renderCheckinButtons(model)}
-                        </div>);
+                        </div>
+                    );
                 })}
             </div>
         );

--- a/src/views/components/student.jsx
+++ b/src/views/components/student.jsx
@@ -25,7 +25,7 @@ export default class Student extends React.Component {
             editMode: false,
             student: updated
         });
-        StudentController.UpdateStudent(updated);
+        StudentController.updateStudent(updated);
     }
 
     render() {

--- a/test/functional/admin-override-item-checkout.js
+++ b/test/functional/admin-override-item-checkout.js
@@ -129,7 +129,11 @@ describe('Admin override on item checkout', function () {
             json: {
                 adminCode: '3214',
                 studentId: 111111,
-                equipmentAddresses: ['iGwEZVHHE']
+                equipment: [
+                    {
+                        address: 'iGwEZVHHE'
+                    }
+                ]
             },
             response: {
                 status: 'success'

--- a/test/functional/item-checkin-student-scanned.js
+++ b/test/functional/item-checkin-student-scanned.js
@@ -8,6 +8,7 @@ import models from '../test-cases/models';
 import students from '../test-cases/students';
 import CartStore from '../../.dist/store/cart-store';
 import StudentStore from '../../.dist/store/student-store';
+
 describe('Checking an item out when new student scanned', function () {
 
     this.timeout(10000);
@@ -89,7 +90,11 @@ describe('Checking an item out when new student scanned', function () {
             json: {
                 adminCode: null,
                 studentId: 123456,
-                equipmentAddresses: ['iGwEZUvfA']
+                equipment: [
+                    {
+                        address: 'iGwEZUvfA'
+                    }
+                ]
             },
             response: {
                 status: 'success'

--- a/test/functional/item-checkout.js
+++ b/test/functional/item-checkout.js
@@ -89,7 +89,11 @@ describe('Checking an item out', function () {
             json: {
                 adminCode: null,
                 studentId: 123456,
-                equipmentAddresses: ['iGwEZUvfA']
+                equipment: [
+                    {
+                        address: 'iGwEZUvfA'
+                    }
+                ]
             },
             response: {
                 status: 'success'
@@ -109,7 +113,6 @@ describe('Checking an item out', function () {
                 data: students[0]
             }
         });
-
 
         return app.client.waitForVisible('.cart input[type="text"]').then(() => {
             return app.client.click('.cart input[type="text"]');
@@ -177,7 +180,6 @@ describe('Checking an item out', function () {
                 data: items[1]
            }
        });
-
         mockServer.expect({
             method: 'get',
             endpoint: 'item',
@@ -195,9 +197,13 @@ describe('Checking an item out', function () {
           json: {
               adminCode: null,
               studentId: 123456,
-              equipmentAddresses: [
-                  'iGwEZVHHE',
-                  'iGwEZVvgu'
+              equipment: [
+                  {
+                      address: 'iGwEZVHHE'
+                  },
+                  {
+                      address: 'iGwEZVvgu'
+                  }
               ]
           },
           response: {

--- a/test/functional/model-checkin.js
+++ b/test/functional/model-checkin.js
@@ -103,7 +103,13 @@ describe('Checking a model in', function () {
                     email: 'mctestersont@msoe.edu',
                     major: 'Engineering Engineering',
                     items: [],
-                    models: [models[2], models[2], models[2], models[2], models[2]]
+                    models: [
+                        {
+                            address: models[2].address,
+                            name: models[2].name,
+                            quantity: 5
+                        }
+                    ]
                 }
             }
         });

--- a/test/functional/model-checkout.js
+++ b/test/functional/model-checkout.js
@@ -205,7 +205,13 @@ describe('Checking a model out', function () {
                     name: 'John von Neumann',
                     status: 'C - Current',
                     items: [],
-                    models: [models[2], models[2]],
+                    models: [
+                        {
+                            address: models[2].address,
+                            name: models[2].name,
+                            quantity: 2
+                        }
+                    ],
                     email: 'vonneumann@msoe.edu',
                     major: 'Chemical Engineering & Mathematics'
                 }

--- a/test/functional/model-checkout.js
+++ b/test/functional/model-checkout.js
@@ -87,7 +87,12 @@ describe('Checking a model out', function () {
             json: {
                 adminCode: null,
                 studentId: 123456,
-                equipmentAddresses: ['m8y7nFnMs']
+                equipment: [
+                    {
+                        address: 'm8y7nFnMs',
+                        quantity: 1
+                    }
+                ]
             },
             response: {
                 status: 'success'
@@ -175,7 +180,12 @@ describe('Checking a model out', function () {
             json: {
                 adminCode: null,
                 studentId: 123456,
-                equipmentAddresses: ['m8y7nFnMs','m8y7nFnMs']
+                equipment: [
+                    {
+                        address: 'm8y7nFnMs',
+                        quantity: 2
+                    }
+                ]
             },
             response: {
                 status: 'success'

--- a/test/test-cases/students.js
+++ b/test/test-cases/students.js
@@ -27,6 +27,17 @@ export default [
         email: 'mctestersont@msoe.edu',
         major: 'Engineering Engineering',
         items: [],
-        models: [models[2], models[2], models[2], models[2], models[2], models[3]]
+        models: [
+            {
+                address: models[2].address,
+                name: models[2].name,
+                quantity: 5
+            },
+            {
+                address: models[3].address,
+                name: models[3].name,
+                quantity: 1
+            }
+        ]
     }
 ]

--- a/test/unit/controllers/components/student.js
+++ b/test/unit/controllers/components/student.js
@@ -5,7 +5,8 @@ import StudentController from '../../../../.dist/controllers/components/student'
 import { Dispatcher } from 'consus-core/flux';
 
 describe("StudentController", () => {
-    describe("UpdateStudent", () => {
+
+    describe("updateStudent", () => {
         let dispatcherSpy, updateStudent;
         beforeEach(() => {
             dispatcherSpy = sinon.spy(Dispatcher, "handleAction");
@@ -21,7 +22,7 @@ describe("StudentController", () => {
                 })
             );
 
-            return StudentController.UpdateStudent({}).then(() => {
+            return StudentController.updateStudent({}).then(() => {
                 assert.isTrue(dispatcherSpy.called);
                 assert.lengthOf(dispatcherSpy.getCall(0).args, 2);
                 assert.strictEqual(dispatcherSpy.getCall(0).args[0], "STUDENT_UPDATED");

--- a/test/unit/controllers/pages/student.js
+++ b/test/unit/controllers/pages/student.js
@@ -268,7 +268,9 @@ describe("StudentController", () => {
             checkOutItems.restore();
             searchStudent.restore();
         });
+
     });
+
     afterEach(() => {
         dispatcherSpy.restore();
         Dispatcher.handleAction("CLEAR_ALL_DATA");
@@ -276,6 +278,7 @@ describe("StudentController", () => {
     });
 
     describe("isValidLongtermData",() => {
+
         it('fails on bad data', () => {
             let today = moment();
             assert.isFalse(StudentController.isValidLongtermData(undefined, 'test'));
@@ -285,11 +288,10 @@ describe("StudentController", () => {
             assert.isTrue(StudentController.isValidLongtermData(today, 'test'));
             assert.isFalse(StudentController.isValidLongtermData(today, undefined));
             assert.isFalse(StudentController.isValidLongtermData(today, null));
-
-
         });
 
     });
+
     afterEach(() => {
         dispatcherSpy.restore();
         Dispatcher.handleAction("CLEAR_ALL_DATA");

--- a/test/unit/lib/api-client.js
+++ b/test/unit/lib/api-client.js
@@ -101,11 +101,26 @@ describe('API Client', () => {
             endpoint: 'checkout',
             json: {
                 studentId: 123456,
-                equipmentAddresses: ['iGwEZUvfA', 'iGwEZVHHE']
+                equipment: [
+                    {
+                        address: 'iGwEZUvfA'
+                    },
+                    {
+                        address: 'iGwEZVHHE'
+                    }
+                ]
             },
             response
         });
-        return checkOutContents(123456, ['iGwEZUvfA', 'iGwEZVHHE']).then(data => {
+        let equipment = [
+            {
+                address: 'iGwEZUvfA'
+            },
+            {
+                address: 'iGwEZVHHE'
+            }
+        ];
+        return checkOutContents(123456, equipment).then(data => {
             assert.isUndefined(data);
             mockServer.validate();
         });
@@ -120,12 +135,27 @@ describe('API Client', () => {
             endpoint: 'checkout',
             json: {
                 studentId: 123456,
-                equipmentAddresses: ['iGwEZUvfA', 'iGwEZVHHE'],
+                equipment: [
+                    {
+                        address: 'iGwEZUvfA'
+                    },
+                    {
+                        address: 'iGwEZVHHE'
+                    }
+                ],
                 adminCode: 'abcdef'
             },
             response
         });
-        return checkOutContents(123456, ['iGwEZUvfA', 'iGwEZVHHE'], 'abcdef').then(data => {
+        let equipment = [
+            {
+                address: 'iGwEZUvfA'
+            },
+            {
+                address: 'iGwEZVHHE'
+            }
+        ];
+        return checkOutContents(123456, equipment, 'abcdef').then(data => {
             assert.isUndefined(data);
             mockServer.validate();
         });
@@ -597,12 +627,27 @@ describe('API Client', () => {
             endpoint: 'checkout',
             json: {
                 studentId: 123456,
-                equipmentAddresses: ['iGwEZUvfA', 'iGwEZVHHE'],
+                equipment: [
+                    {
+                        address: 'iGwEZUvfA'
+                    },
+                    {
+                        address: 'iGwEZVHHE'
+                    }
+                ],
                 adminCode: 'abcdef'
             },
             response
         });
-        return checkOutContents(123456, ['iGwEZUvfA', 'iGwEZVHHE'], 'abcdef').then(data => {
+        let equipment = [
+            {
+                address: 'iGwEZUvfA'
+            },
+            {
+                address: 'iGwEZVHHE'
+            }
+        ];
+        return checkOutContents(123456, equipment, 'abcdef').then(data => {
             assert.isUndefined(data);
             mockServer.validate();
         });
@@ -618,14 +663,29 @@ describe('API Client', () => {
             endpoint: 'checkout/longterm',
             json: {
                 studentId: 123456,
-                equipmentAddresses: ['iGwEZUvfA', 'iGwEZVHHE'],
+                equipment: [
+                    {
+                        address: 'iGwEZUvfA'
+                    },
+                    {
+                        address: 'iGwEZVHHE'
+                    }
+                ],
                 dueDate: today.toDateString(),
                 professor: 'professor',
                 adminCode: 123456
             },
             response
         });
-        return checkOutContentsLongterm(123456, ['iGwEZUvfA', 'iGwEZVHHE'], today.toDateString(), 'professor', 123456).then(data => {
+        let equipment = [
+            {
+                address: 'iGwEZUvfA'
+            },
+            {
+                address: 'iGwEZVHHE'
+            }
+        ];
+        return checkOutContentsLongterm(123456, equipment, today.toDateString(), 'professor', 123456).then(data => {
             assert.deepEqual(data, response.data);
             mockServer.validate();
         });

--- a/test/unit/lib/api-client.js
+++ b/test/unit/lib/api-client.js
@@ -622,23 +622,6 @@ describe('API Client', () => {
         let response = {
             status: 'success'
         };
-        mockServer.expect({
-            method: 'post',
-            endpoint: 'checkout',
-            json: {
-                studentId: 123456,
-                equipment: [
-                    {
-                        address: 'iGwEZUvfA'
-                    },
-                    {
-                        address: 'iGwEZVHHE'
-                    }
-                ],
-                adminCode: 'abcdef'
-            },
-            response
-        });
         let equipment = [
             {
                 address: 'iGwEZUvfA'
@@ -647,6 +630,16 @@ describe('API Client', () => {
                 address: 'iGwEZVHHE'
             }
         ];
+        mockServer.expect({
+            method: 'post',
+            endpoint: 'checkout',
+            json: {
+                studentId: 123456,
+                equipment,
+                adminCode: 'abcdef'
+            },
+            response
+        });
         return checkOutContents(123456, equipment, 'abcdef').then(data => {
             assert.isUndefined(data);
             mockServer.validate();
@@ -658,25 +651,6 @@ describe('API Client', () => {
             status: 'success'
         };
         let today = new Date();
-        mockServer.expect({
-            method: 'post',
-            endpoint: 'checkout/longterm',
-            json: {
-                studentId: 123456,
-                equipment: [
-                    {
-                        address: 'iGwEZUvfA'
-                    },
-                    {
-                        address: 'iGwEZVHHE'
-                    }
-                ],
-                dueDate: today.toDateString(),
-                professor: 'professor',
-                adminCode: 123456
-            },
-            response
-        });
         let equipment = [
             {
                 address: 'iGwEZUvfA'
@@ -685,6 +659,18 @@ describe('API Client', () => {
                 address: 'iGwEZVHHE'
             }
         ];
+        mockServer.expect({
+            method: 'post',
+            endpoint: 'checkout/longterm',
+            json: {
+                studentId: 123456,
+                equipment,
+                dueDate: today.toDateString(),
+                professor: 'professor',
+                adminCode: 123456
+            },
+            response
+        });
         return checkOutContentsLongterm(123456, equipment, today.toDateString(), 'professor', 123456).then(data => {
             assert.deepEqual(data, response.data);
             mockServer.validate();

--- a/test/unit/store/cart-store.js
+++ b/test/unit/store/cart-store.js
@@ -69,7 +69,7 @@ describe('CartStore', () => {
         setTimeout(() => {
             assert.isFalse(CartStore.isOnTimeout());
             done();
-        }, CartStore.TIMEOUT_TIME);
+        }, 2 * CartStore.TIMEOUT_TIME);
     });
 
     it('times out for models', function(done){
@@ -89,7 +89,7 @@ describe('CartStore', () => {
         setTimeout(() => {
             assert.isFalse(CartStore.isOnTimeout());
             done();
-        }, CartStore.TIMEOUT_TIME);
+        }, 2 * CartStore.TIMEOUT_TIME);
     });
 
     it('cancels timeout when new student is scanned', () => {

--- a/test/unit/store/cart-store.js
+++ b/test/unit/store/cart-store.js
@@ -20,7 +20,6 @@ describe('CartStore', () => {
             status: 'AVAILABLE'
         });
         assert.strictEqual(CartStore.getContents()[0].address, '123');
-        assert.strictEqual(CartStore.getContents()[0].status, 'AVAILABLE');
     });
 
     it('should clear items on checkout',() => {

--- a/test/unit/store/cart-store.js
+++ b/test/unit/store/cart-store.js
@@ -69,7 +69,7 @@ describe('CartStore', () => {
         setTimeout(() => {
             assert.isFalse(CartStore.isOnTimeout());
             done();
-        }, 2 * CartStore.TIMEOUT_TIME);
+        }, CartStore.TIMEOUT_TIME);
     });
 
     it('times out for models', function(done){
@@ -89,7 +89,7 @@ describe('CartStore', () => {
         setTimeout(() => {
             assert.isFalse(CartStore.isOnTimeout());
             done();
-        }, 2 * CartStore.TIMEOUT_TIME);
+        }, CartStore.TIMEOUT_TIME);
     });
 
     it('cancels timeout when new student is scanned', () => {


### PR DESCRIPTION
### Summary

**>>> Test and merge with the sister PR! TheFourFifths/consus/pull/94 <<<**

This refactors the data model for models which have been checked out. Rather than storing them as `[model1, model1, model1, model2]`, they'll be stored as `[{address: model1.address, quantity: 3}, {address: model2.address, quantity: 1}]`. This makes them much easier to work with.

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Review the code for sanity.
2. Test the client and server, both on the `refactor-model-TFF-226` branch, to manually make sure that everything still works (particularly model check-in and checkout!).
3. Make sure I didn't miss any needed documentation changes.
4. Run the functional tests locally.

### Links

- [TFF-226](https://msoese.atlassian.net/browse/TFF-226)
- TheFourFifths/consus/pull/94
