### PR TITLE
[TFF-227] Nag less when leaving a model edit page without changing anything

### DIFF
--- a/src/views/components/edit-model-form.jsx
+++ b/src/views/components/edit-model-form.jsx
@@ -37,12 +37,14 @@ export default class EditModelForm extends React.Component {
             this.state = {
                 fileOversize: false,
                 showFileSizeModal: false,
-                model: null
+                model: null,
+                hasUnsavedChange: false
             };
         } else {
             this.state = {
                 fileOversize: false,
                 showFileSizeModal: false,
+                hasUnsavedChange: false,
 
                 model: props.model,
                 name: props.model.name,
@@ -92,48 +94,56 @@ export default class EditModelForm extends React.Component {
 
     changeName(e) {
         this.setState({
+            hasUnsavedChange: true,
             name: e.target.value
         });
     }
 
     changeDescription(e) {
         this.setState({
+            hasUnsavedChange: true,
             description: e.target.value
         });
     }
 
     changeManufacturer(e) {
         this.setState({
+            hasUnsavedChange: true,
             manufacturer: e.target.value
         });
     }
 
     changeVendor(e) {
         this.setState({
+            hasUnsavedChange: true,
             vendor: e.target.value
         });
     }
 
     changeLocation(e) {
         this.setState({
+            hasUnsavedChange: true,
             location: e.target.value
         });
     }
 
     changePrice(e) {
         this.setState({
+            hasUnsavedChange: true,
             price: e.target.value
         });
     }
 
     changeCount(e){
         this.setState({
+            hasUnsavedChange: true,
             count: e.target.value
         });
     }
 
-    changeStock(e){
+    changeStock(){
         this.setState({
+            hasUnsavedChange: true,
             changeStock: !this.state.checked,
             checked: !this.state.checked
         });
@@ -141,6 +151,7 @@ export default class EditModelForm extends React.Component {
 
     changeInStock(e){
         this.setState({
+            hasUnsavedChange: true,
             inStock: e.target.value
         });
     }
@@ -149,12 +160,14 @@ export default class EditModelForm extends React.Component {
         let file = e.target.files[0];
         if (bytesToBase64Size(file.size) > MAX_FILESIZE) {
             this.setState({
+                hasUnsavedChange: true,
                 showFileSizeModal: true,
                 fileOversize: true
             });
             return;
         } else {
             this.setState({
+                hasUnsavedChange: true,
                 showFileSizeModal: false,
                 fileOversize: false
             });
@@ -196,9 +209,13 @@ export default class EditModelForm extends React.Component {
     }
 
     allModels() {
-        this.setState({
-            popConfirmModal: true
-        });
+        if (this.state.hasUnsavedChange) {
+            this.setState({
+                popConfirmModal: true
+            });
+        } else {
+            ModelFormController.getModels();
+        }
     }
 
     handleConfirmModal(bool){

--- a/src/views/components/edit-model-form.jsx
+++ b/src/views/components/edit-model-form.jsx
@@ -85,7 +85,6 @@ export default class EditModelForm extends React.Component {
                 });
             });
         }
-        OmnibarController.setWarnBeforeExiting(true);
     }
 
     componentWillUnmount(){
@@ -97,6 +96,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             name: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeDescription(e) {
@@ -104,6 +104,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             description: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeManufacturer(e) {
@@ -111,6 +112,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             manufacturer: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeVendor(e) {
@@ -118,6 +120,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             vendor: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeLocation(e) {
@@ -125,6 +128,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             location: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changePrice(e) {
@@ -132,6 +136,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             price: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeCount(e){
@@ -139,6 +144,7 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             count: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeStock(){
@@ -147,6 +153,7 @@ export default class EditModelForm extends React.Component {
             changeStock: !this.state.checked,
             checked: !this.state.checked
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changeInStock(e){
@@ -154,20 +161,21 @@ export default class EditModelForm extends React.Component {
             hasUnsavedChange: true,
             inStock: e.target.value
         });
+        OmnibarController.setWarnBeforeExiting(true);
     }
 
     changePhoto(e) {
+        this.setState({ hasUnsavedChange: true });
+        OmnibarController.setWarnBeforeExiting(true);
         let file = e.target.files[0];
         if (bytesToBase64Size(file.size) > MAX_FILESIZE) {
             this.setState({
-                hasUnsavedChange: true,
                 showFileSizeModal: true,
                 fileOversize: true
             });
             return;
         } else {
             this.setState({
-                hasUnsavedChange: true,
                 showFileSizeModal: false,
                 fileOversize: false
             });

--- a/test/functional/edit-model-leave-confirmation.js
+++ b/test/functional/edit-model-leave-confirmation.js
@@ -51,7 +51,7 @@ describe('Edit model leave confirmation', function () {
         return app.client.click('#view-models').then(() => {
             return app.client.waitForVisible('#models', 5000);
         }).then(() => {
-            return app.client.click('.actionArea img[src="../assets/images/edit.svg"]')
+            return app.client.click('.actionArea img[src*="edit"]');
         }).then(() => {
             return app.client.waitForVisible(".create-model-form", 5000);
         }).then(() => {
@@ -59,8 +59,47 @@ describe('Edit model leave confirmation', function () {
         });
     });
 
+    it('does not warn you before leaving an unchanged model', () => {
+        mockServer.expect({
+            method: 'get',
+            endpoint: 'model/all',
+            response: {
+                status: 'success',
+                data: {
+                    models
+                }
+            }
+        });
+
+        mockServer.expect({
+            method: 'get',
+            endpoint: 'model',
+            qs: {
+                address: models[0].address
+            },
+            response: {
+                status: "success",
+                data: models[0]
+            }
+        });
+
+        return app.client.click('.create-model-form > button').then(() => {
+            return app.client.waitForVisible('#models');
+        }).then(() => {
+            return app.client.click('.actionArea img[src*="edit"]');
+        }).then(() => {
+            return app.client.waitForVisible('.create-model-form');
+        }).then(() => {
+            mockServer.validate();
+        });
+    });
+
     it('warns you before leaving the page', () => {
-        return app.client.click('.create-model-form>button').then(() => {
+        return app.client.click('#name input').then(() => {
+            return app.client.keys('change');
+        }).then(() => {
+            return app.client.click('.create-model-form > button')
+        }).then(() => {
             return app.client.waitForVisible('.modal');
         }).then(() => {
             return app.client.click('.modal-content button');

--- a/test/functional/edit-model-leave-confirmation.js
+++ b/test/functional/edit-model-leave-confirmation.js
@@ -59,7 +59,7 @@ describe('Edit model leave confirmation', function () {
         });
     });
 
-    it('does not warn you before leaving an unchanged model', () => {
+    it('does not warn you before leaving an unchanged model via "View all Models" button', () => {
         mockServer.expect({
             method: 'get',
             endpoint: 'model/all',
@@ -70,7 +70,6 @@ describe('Edit model leave confirmation', function () {
                 }
             }
         });
-
         mockServer.expect({
             method: 'get',
             endpoint: 'model',
@@ -84,6 +83,44 @@ describe('Edit model leave confirmation', function () {
         });
 
         return app.client.click('.create-model-form > button').then(() => {
+            return app.client.waitForVisible('#models');
+        }).then(() => {
+            return app.client.click('.actionArea img[src*="edit"]');
+        }).then(() => {
+            return app.client.waitForVisible('.create-model-form');
+        }).then(() => {
+            mockServer.validate();
+        });
+    });
+
+    it('does not warn you before leaving an unchanged model via Omnibar', () => {
+        mockServer.expect({
+            method: 'get',
+            endpoint: 'model/all',
+            response: {
+                status: 'success',
+                data: {
+                    models
+                }
+            }
+        });
+        mockServer.expect({
+            method: 'get',
+            endpoint: 'model',
+            qs: {
+                address: models[0].address
+            },
+            response: {
+                status: "success",
+                data: models[0]
+            }
+        });
+
+        return app.client.click('#omnibar img').then(() => {
+            return app.client.waitForVisible('#index');
+        }).then(() => {
+            return app.client.click('#view-models');
+        }).then(() => {
             return app.client.waitForVisible('#models');
         }).then(() => {
             return app.client.click('.actionArea img[src*="edit"]');


### PR DESCRIPTION
### Summary

I disliked being nagged about losing unsaved changes that I didn't make whilst visiting a model edit page. I made it stop doing that.
It could still be improved by only nagging when there is a difference between the "server's model" and the current model state.

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Read codes
1. Go to model page
1. Try to leave: without changing anything; changing each individual field/photo.
1. Notice the nagging modal only appears when you're changed a field/photo (at least once).

### Links

- [TFF-227](https://msoese.atlassian.net/browse/TFF-227)
