### PR TITLE
[TFF-230] Extend due dates to a week from today

### DIFF
--- a/src/controllers/components/student-panel.js
+++ b/src/controllers/components/student-panel.js
@@ -83,6 +83,9 @@ export default class StudentPanelController {
             Dispatcher.handleAction('SAVE_ITEM', {
                 itemAddress
             });
+            return searchStudent(StudentStore.getStudent().id);
+        }).then(student => {
+            Dispatcher.handleAction('STUDENT_FOUND', student);
         });
     }
 
@@ -91,6 +94,9 @@ export default class StudentPanelController {
             Dispatcher.handleAction('SAVE_MODEL', {
                 modelAddress
             });
+            return searchStudent(StudentStore.getStudent().id);
+        }).then(student => {
+            Dispatcher.handleAction('STUDENT_FOUND', student);
         });
     }
 

--- a/src/views/components/saved-equipment.jsx
+++ b/src/views/components/saved-equipment.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import moment from 'moment-timezone';
 import ModelStore from '../../store/model-store';
 import StudentPanelController from '../../controllers/components/student-panel';
 import OmnibarController from '../../controllers/components/omnibar';
@@ -15,17 +16,20 @@ export default class SavedEquipment extends React.Component {
         if (!model) {
             return null;
         }
+        let dueDate = moment.tz(item.timestamp * 1000, 'America/Chicago');
         return (
             <span>
-                {model.name} {item.timestamp < Math.floor(Date.now()/1000) ? '(overdue)' : ''} <i>{item.address}</i>
+                {model.name} {item.timestamp < Math.floor(Date.now()/1000) ? '(overdue)' : ''} <i>{item.address} Due on: {dueDate.format('MMMM Do YYYY, h:mm:ss a')}</i>
             </span>
         );
     }
 
     renderModelInfo(model) {
+        let dueDate = moment.tz(model.dueDate * 1000, 'America/Chicago');
         return (
             <span>
                 {model.name} <i>{model.address}</i> ({model.quantity})
+                {model.dueDate < Math.floor(Date.now() / 1000) ? '(overdue)' : ''} <i>Due on: {dueDate.format('MMMM Do YYYY, h:mm:ss a')}</i>
             </span>
         );
     }


### PR DESCRIPTION
### Summary

Saved items and models will now have a 7-week due date. After this, Tech Support can disassemble the equipment and check it in.

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Run this and the server on `saved-due-date-TFF-230`
2. Scan a student
3. Check out a model and item
4. Save them
5. View the due date, which should be a week from today

### Links

- [TFF-230](https://msoese.atlassian.net/browse/TFF-230)
- TheFourFifths/consus/pull/113
